### PR TITLE
fix: resolve CodeQL vulnerabilities (polynomial-redos, double-escaping)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biensperience",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "Biensperience: a visual travel experience planning platform (self-hostable)",
   "license": "AGPL-3.0-only",
   "author": "Goke Pelemo",

--- a/src/components/BienBotPanel/BienBotPanel.jsx
+++ b/src/components/BienBotPanel/BienBotPanel.jsx
@@ -650,9 +650,9 @@ export default function BienBotPanel({
       if (!items?.length || isStreaming || isLoading) return;
       const itemNames = items
         .map(i => (i.text || i.content || '')
-          .replace(/&amp;/g, '&').replace(/&#39;/g, "'").replace(/&apos;/g, "'")
+          .replace(/&#39;/g, "'").replace(/&apos;/g, "'")
           .replace(/&quot;/g, '"').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
-          .replace(/&nbsp;/g, ' ').trim())
+          .replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&').trim())
         .filter(Boolean);
       if (!itemNames.length) return;
       const msg = `Add these plan items: ${itemNames.join(', ')}`;

--- a/src/components/BienBotPanel/SuggestionList.jsx
+++ b/src/components/BienBotPanel/SuggestionList.jsx
@@ -138,7 +138,7 @@ export default function SuggestionList({ data, onAddSelected, disabled, existing
                       {isSelected && <CheckIcon />}
                     </span>
                     <span className={styles.suggestionItemContent}>
-                      <span className={styles.suggestionItemText}>{(item.text || item.content || '').replace(/&amp;/g, '&').replace(/&#39;/g, "'").replace(/&apos;/g, "'").replace(/&quot;/g, '"').replace(/&nbsp;/g, ' ')}</span>
+                      <span className={styles.suggestionItemText}>{(item.text || item.content || '').replace(/&#39;/g, "'").replace(/&apos;/g, "'").replace(/&quot;/g, '"').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&')}</span>
                       {sources && (
                         <span className={styles.suggestionItemSource}>
                           from {sources}

--- a/utilities/bienbot-action-executor.js
+++ b/utilities/bienbot-action-executor.js
@@ -1340,7 +1340,7 @@ async function executeCreateInvite(payload, user) {
   const expiresAt = new Date(Date.now() + expires_in_days * 24 * 60 * 60 * 1000);
 
   // Validate email format when provided
-  if (email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+  if (email && !/^[^\s@]+@[^\s@.]+\.[^\s@]+$/.test(email)) {
     return { statusCode: 400, body: { success: false, error: 'Invalid email address format' } };
   }
 

--- a/utilities/bienbot-external-data.js
+++ b/utilities/bienbot-external-data.js
@@ -1347,14 +1347,15 @@ async function reformulateWikivoyagePlanItems(items, destinationName, user) {
       if (typeof rewritten === 'string' && rewritten.trim().length > 0) {
         // LLMs occasionally output HTML entities (e.g. &#39; for apostrophe).
         // Decode them so plan item text is stored as plain text.
+        // &amp; is decoded last to prevent double-unescaping (e.g. &amp;#39; → &#39; → ')
         const decoded = rewritten.trim()
-          .replace(/&amp;/g, '&')
           .replace(/&quot;/g, '"')
           .replace(/&#39;/g, "'")
           .replace(/&apos;/g, "'")
           .replace(/&lt;/g, '<')
           .replace(/&gt;/g, '>')
-          .replace(/&nbsp;/g, ' ');
+          .replace(/&nbsp;/g, ' ')
+          .replace(/&amp;/g, '&');
         return { ...item, name: decoded };
       }
       return item; // keep original on per-item failure


### PR DESCRIPTION
- Fix polynomial ReDoS in email regex (bienbot-action-executor.js) Change domain segment from [^\s@]+ to [^\s@.]+ to prevent catastrophic backtracking
- Fix double-unescaping in HTML entity decode chains (3 files) Move &amp; decoding to last to prevent &amp;#39; -> &#39; -> ' double-decode

Closes CodeQL alerts #229, #230, #231, #232

## Summary by Sourcery

Resolve security and decoding issues in BienBot email validation and HTML entity handling.

Bug Fixes:
- Prevent polynomial-time ReDoS in invite email validation by tightening the email regex domain segment.
- Avoid double-unescaping of HTML entities in BienBot text processing by decoding &amp; last in the chain across utilities and UI components.

Chores:
- Bump package version from 0.12.5 to 0.12.6 to reflect the security-related fixes.