### PR TITLE
Fix last update from Sourcery feedback

### DIFF
--- a/ai.md
+++ b/ai.md
@@ -2298,7 +2298,7 @@ The block is suppressed when:
 **Discovery ranking** (`buildDiscoveryContext()`):
 - Calls `affinityCache.getAffinityMap(userId)` once before iterating over experience candidates.
 - For each candidate, looks up `cachedAffinity.score` from the map.
-- Falls back to a cold `computeAffinityScore()` call (using undecked signals) when no cache entry exists.
+- Falls back to a cold `computeAffinityScore()` call (using undecayed signals) when no cache entry exists.
 
 **Cache-miss fallback** (`controllers/api/bienbot.js` — `POST /api/bienbot/chat`):
 - Before building the invoke context, the controller checks the affinity cache.

--- a/ai.md
+++ b/ai.md
@@ -2048,3 +2048,307 @@ Summary is cached; re-opening the panel within 6 hours skips the LLM call and re
 | 8 | `src/utilities/bienbot-api.js` | Frontend API calls, `broadcastEvent` on mutations |
 | 9 | `src/hooks/useBienBot.js` | Conversation state, streaming, pending action management; `resumeSession` triggers greeting |
 | 10 | `.env.example` | Document `BIENBOT_*` env vars (rate limits, token budgets) |
+
+---
+
+## Hidden Signals & Affinity
+
+### 7.1 Hidden Signals Overview
+
+Hidden signals are an 8-dimensional behavioral vector stored per user, tracking implicit preferences derived from interactions with plan items and experiences.
+
+**Dimensions** (`DIMENSIONS` in `utilities/hidden-signals.js`):
+
+| Dimension | Description |
+|-----------|-------------|
+| `energy` | Activity intensity preference |
+| `novelty` | Preference for new or unfamiliar experiences |
+| `budget_sensitivity` | Cost-consciousness |
+| `social` | Preference for group or social activities |
+| `structure` | Need for scheduled, organised itineraries |
+| `food_focus` | Emphasis on culinary experiences |
+| `cultural_depth` | Interest in museums, history, and local culture |
+| `comfort_zone` | Willingness to try unfamiliar or challenging activities |
+
+**Value range**: All dimensions are clamped to `[0, 1]`. The neutral midpoint is `0.5`.
+
+**EMA update formula**: Each dimension is updated via Exponential Moving Average (α = `0.20`):
+
+```
+target  = clamp01(current_val + influence_strength × combined_weight)
+new_val = clamp01((1 − 0.20) × current_val + 0.20 × target)
+combined_weight = EVENT_WEIGHT_MAP[event.type] × event.value
+```
+
+`influence_strength` comes from `ACTIVITY_TYPE_SIGNAL_MAP[activity_type][dimension]`. If no activity type is associated with the event, the dimension is not nudged.
+
+**Per-event confidence increment**: `+0.05` per event processed, clamped to `[0, 1]`.
+
+**Storage** (`user.hidden_signals`): a flat object with one key per dimension plus:
+- `confidence` — number of contributing events (normalised to `[0, 1]`)
+- `last_updated` — ISO timestamp of the most recent update
+
+**Decay** (`applySignalDecay(signals)`):
+- Applied before affinity computation, not written back to the database.
+- Uses a half-life of **30 days** (`DECAY_HALF_LIFE_DAYS`).
+- For each dimension: `new_val = clamp01(0.5 + (val − 0.5) × exp(−days / 30))`
+- Confidence also decays: `new_confidence = clamp01(confidence × exp(−days / 30))`
+- If elapsed time is less than 1 day, the signal vector is returned unchanged.
+- Skipped entirely if `signals.last_updated` is absent.
+
+**Raw event log**: Up to 200 events are retained in `user.hidden_signal_events` (capped via `$slice: -200` on every write).
+
+---
+
+### 7.2 Content Signals
+
+Content signals are computed metrics stored on each experience in `experience.signals`, reflecting its quality and engagement level.
+
+**Fields**:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `signals.trustScore` | Number `[0, 1]` | Weighted quality indicator |
+| `signals.popularity.planCount` | Number | Total distinct plans created |
+| `signals.popularity.planCountWithActivity` | Number | Plans with at least one activity-typed item |
+| `signals.popularity.completedPlanCount` | Number | Plans with at least one completed item |
+| `signals.computed_at` | Date | Timestamp of last signal computation |
+
+**`trustScore` formula** (`computeTrustScore()`):
+
+```
+score = 0
+if isCurator:      score += w.curator         // default 0.30 (normalised)
+if isPublic:       score += w.public          // default 0.20 (normalised)
+score += clamp01(completionRate) × w.completionRate  // default 0.20 (normalised)
+if planCount >= w.minPlanItems: score += w.base       // default 0.10 (normalised)
+trustScore = clamp01(score)
+```
+
+Weights are read from `signals-config.trustScore` (normalised to sum to 1 at startup). `minPlanItems` defaults to `1` and is excluded from normalisation.
+
+**`popularity` score** (`computePopularityScore()`): Weighted sum of three normalised plan-count dimensions. Normalisation is done relative to per-destination maximums so scores are meaningful within context:
+
+```
+score = w.planCount × (planCount / maxPlanCount)
+      + w.planWithActivity × (planCountWithActivity / maxPlanCountWithActivity)
+      + w.completedPlans   × (completedPlanCount   / maxCompletedPlanCount)
+```
+
+Default weights (normalised): `planCount: 0.50`, `planWithActivity: 0.30`, `completedPlans: 0.20`.
+
+**`reviews`**: Schema field present (`avgRating` weight exists in config), not yet populated. Placeholder for future review data.
+
+**`updateExperienceSignals(experienceId)`**: Fire-and-forget function that:
+1. Loads the experience and its creator user.
+2. Runs a single MongoDB aggregation on the Plan collection for the three popularity dimensions.
+3. Calls `computeTrustScore()` with the creator's curator flag and the experience's `public` field.
+4. Atomically writes all fields to `experience.signals` via `$set`.
+
+**Trigger points**:
+- After plan create (`controllers/api/plans.js` → `createPlan`)
+- After plan delete (`controllers/api/plans.js` → `deletePlan`)
+- Async refresh on experience page load (via `refreshSignalsAndAffinity()`)
+
+---
+
+### 7.3 Affinity System
+
+The affinity system computes a scalar similarity score between a user's behavioral vector and an experience's behavioral vector.
+
+**`computeAffinityScore(userSignals, entitySignals, config)`**:
+
+```
+formula: 1 − weighted_mean_absolute_difference
+
+weightedDiff = Σ (config.affinity[dim] × |userSignals[dim] − entitySignals[dim]|)
+               for each dim in DIMENSIONS
+
+score = clamp01(1 − weightedDiff)
+```
+
+Affinity dimension weights (normalised defaults from `signals-config.affinity`):
+
+| Dimension | Default Weight (pre-normalisation) |
+|-----------|-------------------------------------|
+| `energy` | 0.15 |
+| `novelty` | 0.15 |
+| `budget_sensitivity` | 0.10 |
+| `social` | 0.10 |
+| `structure` | 0.10 |
+| `food_focus` | 0.15 |
+| `cultural_depth` | 0.15 |
+| `comfort_zone` | 0.10 |
+
+**Confidence gating**: If either `userSignals.confidence` or `entitySignals.confidence` is below `config.affinity.confidenceThreshold` (default `0.20`), the function returns `config.affinity.neutralAffinityScore` (default `0.50`) immediately without computing the weighted difference.
+
+**`top_dims` extraction** (computed in `computeAndCacheAffinity()`):
+
+```javascript
+dimEntries = DIMENSIONS.map(dim => ({
+  dim,
+  user_val:   decayedUser[dim],
+  entity_val: decayedEntity[dim],
+  delta:      Math.abs(decayedUser[dim] - decayedEntity[dim])
+}));
+
+top_dims = dimEntries
+  .filter(d => d.delta < 0.3)      // only well-aligned dimensions
+  .sort((a, b) => a.delta - b.delta) // ascending by delta (best alignment first)
+  .slice(0, 3);                     // at most 3 dimensions
+```
+
+`top_dims` is stored in the affinity cache entry alongside the score and surfaced to BienBot for narrative generation.
+
+---
+
+### 7.4 Affinity Cache
+
+**File**: `utilities/affinity-cache.js`
+
+Pre-computed affinity entries are cached to avoid recomputing the signal pipeline on every BienBot request.
+
+**Provider selection**: Redis when `REDIS_URL` is set; MongoDB fallback otherwise.
+
+**Redis key schema**: `bien:affinity:{userId}` — stores a JSON array of all affinity entries for that user.
+
+**TTL**: `AFFINITY_CACHE_TTL_MS` (default **6 hours**). Applied via `SETEX` in the Redis provider. The MongoDB provider does not enforce TTL; entries persist until evicted by the 50-entry cap.
+
+**50-entry cap**:
+- Redis: `entries.slice(-MAX_ENTRIES)` before writing back.
+- MongoDB: `$push` with `$slice: -50` after removing the existing entry for the experience.
+
+**Cache entry shape**:
+```javascript
+{
+  experience_id: ObjectId,
+  score: Number,          // [0, 1] affinity score
+  top_dims: [{            // up to 3 best-aligned dimensions
+    dim: String,
+    user_val: Number,
+    entity_val: Number,
+    delta: Number
+  }],
+  computed_at: Date
+}
+```
+
+**MongoDB storage**: `user.affinity_cache` — subdocument array on the User model.
+
+**Public API**:
+
+| Function | Signature | Returns |
+|----------|-----------|---------|
+| `getAffinityEntry` | `(userId, experienceId)` | `Promise<Object\|null>` |
+| `setAffinityEntry` | `(userId, experienceId, entry)` | `Promise<void>` |
+| `getAffinityMap` | `(userId)` | `Promise<Map<experienceIdString, entry>>` |
+| `resetAffinityCache` | `()` | `void` — resets singleton (tests only) |
+
+---
+
+### 7.5 Staleness Refresh
+
+**`SIGNALS_STALENESS_MS`**: Default **15 minutes** (900,000 ms). Configurable via `SIGNALS_CONFIG` env var (see 7.7).
+
+**`refreshSignalsAndAffinity(experienceId, userId, computedAt)`**:
+
+```
+1. isStale = !computedAt || (Date.now() − computedAt > SIGNALS_STALENESS_MS)
+2. if isStale: await updateExperienceSignals(experienceId)
+              // awaited so affinity reads the fresh signals
+3. await computeAndCacheAffinity(userId, experienceId)
+```
+
+Never throws — errors are logged and silently absorbed.
+
+**`computeAndCacheAffinity(userId, experienceId)`**:
+1. Validates both IDs as Mongoose ObjectIds; returns early if invalid.
+2. Loads `user.hidden_signals` and `experience.hidden_signals` in parallel.
+3. Applies `applySignalDecay()` to both vectors.
+4. Calls `computeAffinityScore()` to get the scalar score.
+5. Computes `top_dims` (delta < 0.3, sorted ascending, top 3).
+6. Writes the entry to the affinity cache via `setAffinityEntry()`.
+
+**Trigger sites** (via `setImmediate` after sending the HTTP response):
+
+| Controller | Endpoint | `computedAt` passed |
+|-----------|----------|---------------------|
+| `controllers/api/experiences.js` — `showExperience` | `GET /api/experiences/:id` | Actual `experience.signals.computed_at` |
+| `controllers/api/plans.js` — `getPlanById` | `GET /api/plans/:id` | `null` (always refresh) |
+
+Using `setImmediate` ensures the refresh never delays the HTTP response to the client.
+
+---
+
+### 7.6 BienBot Integration
+
+**Invoke context** (`utilities/bienbot-context-builders.js`):
+
+`buildContextForInvokeContext()` calls `appendAffinityBlock()` for `experience` and `plan` entity types. The affinity block is appended to the LLM context string in the format:
+
+```
+[AFFINITY] User affinity for this experience: {score} ({label} — {dims})
+```
+
+The block is suppressed when:
+- The affinity entry is absent (cache miss with no fallback data).
+- `Math.abs(score − 0.5) <= 0.05` (score is indistinguishable from neutral).
+- `top_dims` is empty.
+
+**Discovery ranking** (`buildDiscoveryContext()`):
+- Calls `affinityCache.getAffinityMap(userId)` once before iterating over experience candidates.
+- For each candidate, looks up `cachedAffinity.score` from the map.
+- Falls back to a cold `computeAffinityScore()` call (using undecked signals) when no cache entry exists.
+
+**Cache-miss fallback** (`controllers/api/bienbot.js` — `POST /api/bienbot/chat`):
+- Before building the invoke context, the controller checks the affinity cache.
+- On a cache miss, it **awaits** `computeAndCacheAffinity(userId, experienceId)` — this is the only blocking call site; all other triggers are fire-and-forget.
+- The freshly computed entry is then available to `buildContextForInvokeContext()`.
+
+**System prompt — `AFFINITY SIGNALS` rule block**:
+- Instructs the LLM to reference affinity and name the relevant dimensions when a user asks open-ended fit questions (e.g. "Is this experience right for me?").
+- Directs the LLM to suppress raw numeric scores in responses; use qualitative labels instead.
+- The LLM remains silent about affinity when the score is absent or neutral.
+
+---
+
+### 7.7 Signals Config
+
+**File**: `utilities/signals-config.js`
+
+All signal weights and formula coefficients are loaded once at startup from the `SIGNALS_CONFIG` environment variable (a JSON string), deep-merged with hardcoded defaults, validated, and frozen.
+
+**Loading flow**:
+1. Parse `SIGNALS_CONFIG` JSON (falls back to defaults on parse error or absence).
+2. Deep-merge with `DEFAULTS` (one level deep per group).
+3. Validate each weight group: weight keys must be finite and `>= 0`; `minPlanItems` must be a non-negative integer; `confidenceThreshold` and `neutralAffinityScore` must be in `[0, 1]`.
+4. Normalise each weight group so its weight keys sum to `1.0`.
+5. Pass through top-level scalar keys unchanged (only range-checked).
+6. `Object.freeze()` the result — single immutable singleton for the process lifetime.
+
+**Weight groups** (each normalised to sum to 1):
+
+| Group | Keys |
+|-------|------|
+| `trustScore` | `curator`, `public`, `completionRate`, `base` (+ non-weight: `minPlanItems`) |
+| `popularity` | `planCount`, `planWithActivity`, `completedPlans` |
+| `reviews` | `avgRating` |
+| `affinity` | `energy`, `novelty`, `budget_sensitivity`, `social`, `structure`, `food_focus`, `cultural_depth`, `comfort_zone` (+ non-weight: `confidenceThreshold`, `neutralAffinityScore`) |
+| `formula` | `adaptiveFactor`, `trustScore`, `popularity`, `recencyBoost`, `affinity` |
+
+**Top-level scalar keys** (not normalised — range-checked only):
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `SIGNALS_STALENESS_MS` | `900000` (15 min) | Max age before content signals are recomputed |
+| `AFFINITY_CACHE_TTL_MS` | `21600000` (6 hr) | Redis TTL for cached affinity entries |
+
+**Override example** (single key):
+```bash
+SIGNALS_CONFIG='{"SIGNALS_STALENESS_MS":300000}'
+```
+
+**Override example** (weight group partial override — remaining weights are renormalised):
+```bash
+SIGNALS_CONFIG='{"affinity":{"energy":0.30,"cultural_depth":0.30}}'
+```

--- a/controllers/api/bienbot.js
+++ b/controllers/api/bienbot.js
@@ -39,6 +39,8 @@ const path = require('path');
 const { GatewayError } = require('../../utilities/ai-gateway');
 const { callProvider, getApiKey, getProviderForTask, AI_TASKS } = require('./ai');
 const BienBotSession = require('../../models/bienbot-session');
+const affinityCache = require('../../utilities/affinity-cache');
+const { computeAndCacheAffinity } = require('../../utilities/hidden-signals');
 
 // Lazy-loaded models
 let Destination, Experience, Plan, User;
@@ -101,6 +103,25 @@ const ENTITY_LABEL_MAP = {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Resolve the experience ID from an invoke context object.
+ * Returns the experience_id string for 'experience' entities.
+ * Returns null for 'plan' entities (session.context not available at call site)
+ * and for all other entity types.
+ *
+ * @param {Object} invokeContext - session.invoke_context or resolved invoke context
+ * @returns {string|null}
+ */
+function resolveExperienceIdFromInvokeContext(invokeContext) {
+  if (!invokeContext) return null;
+  if (invokeContext.entity === 'experience') {
+    return invokeContext.entity_id?.toString() ?? null;
+  }
+  // For 'plan' entities the session context (which holds experience_id) is not
+  // yet available at the call site — return null to skip the blocking fallback.
+  return null;
+}
 
 /**
  * Strip null bytes from a string to prevent injection.
@@ -261,6 +282,19 @@ function buildSystemPrompt({ invokeLabel, invokeEntityType, contextDescription, 
     '- Always name the specific entity you recommend and give ONE concise reason tied to their travel personality.',
     '- Include the recommended entity in entity_refs.',
     '- If [TRAVEL SIGNALS] is absent or confidence is too low, fall back to objective signals (soonest trip date, most overdue item, most items remaining) and explain the reasoning briefly.',
+    '',
+    'AFFINITY SIGNALS — entity-level match:',
+    '- The invoke context may include an [AFFINITY] line for the experience or plan currently open:',
+    '  e.g. "User affinity for this experience: 0.82 (strong alignment — food_focus, cultural_depth)"',
+    '- Affinity score interpretation: < 0.4 = low match, 0.4–0.6 = moderate, > 0.6 = strong.',
+    '- When [AFFINITY] is present and the user asks an open-ended question about the current entity',
+    '  ("is this a good fit for me?", "should I add more items?", "what do you think of this?"),',
+    '  reference the affinity and top aligning dimensions in your answer.',
+    '- Name the specific dimensions driving the match',
+    '  (e.g. "your food_focus and cultural_depth align well with this experience").',
+    '- Do NOT surface the raw numeric score unprompted. Prefer natural language:',
+    '  "this experience is a strong match for your travel style" over "your affinity score is 0.82".',
+    '- When [AFFINITY] is absent or neutral (score 0.45–0.55), do not invent affinity reasoning.',
     '',
     'GREETING CONTEXT SECTIONS — follow-up handling:',
     '- Every entity mentioned in the greeting carries an inline entityJSON ref. Use those IDs for actions and navigation without asking the user.',
@@ -1714,6 +1748,29 @@ exports.chat = async (req, res) => {
       entity_id: invokeContext.id,
       entity_label: invokeLabel
     };
+
+    // Ensure affinity is cached for this entity before building invoke context.
+    // If the background refresh has not yet run, compute now (blocking) so the
+    // invoke context receives enriched affinity data on first open.
+    if (invokeContext.entity === 'experience' || invokeContext.entity === 'plan') {
+      const experienceId = resolveExperienceIdFromInvokeContext(resolvedInvokeContext);
+      if (experienceId) {
+        try {
+          const existing = await affinityCache.getAffinityEntry(userId, experienceId);
+          if (!existing) {
+            // Cache miss — compute now (blocking) so invoke context is enriched
+            await computeAndCacheAffinity(userId, experienceId);
+          }
+        } catch (affinityErr) {
+          // Non-fatal — proceed without affinity enrichment
+          logger.warn('[bienbot] Affinity cache-miss fallback failed, continuing without it', {
+            userId,
+            experienceId,
+            error: affinityErr.message
+          });
+        }
+      }
+    }
 
     // Build context block for invokeContext
     const contextOptions = {};

--- a/controllers/api/experiences.js
+++ b/controllers/api/experiences.js
@@ -12,7 +12,7 @@ const { hasFeatureFlag } = require('../../utilities/feature-flags');
 const { broadcastEvent } = require('../../utilities/websocket-server');
 const { ARCHIVE_USER, isArchiveUser } = require('../../utilities/system-users');
 const { successResponse, errorResponse, paginatedResponse, validateObjectId } = require('../../utilities/controller-helpers');
-const { aggregateGroupSignals } = require('../../utilities/hidden-signals');
+const { aggregateGroupSignals, refreshSignalsAndAffinity } = require('../../utilities/hidden-signals');
 const { ensureDefaultPhotoConsistency, setDefaultPhotoByIndex } = require('../../utilities/photo-utils');
 const { createPlanItemLocation } = require('../../utilities/address-utils');
 
@@ -867,7 +867,17 @@ async function showExperience(req, res) {
       experience.max_planning_days = 0;
     }
 
-    return successResponse(res, experience, 'Experience retrieved successfully');
+    successResponse(res, experience, 'Experience retrieved successfully');
+    if (req.user) {
+      setImmediate(() =>
+        refreshSignalsAndAffinity(
+          experience._id.toString(),
+          req.user._id.toString(),
+          experience.signals?.computed_at ?? null
+        )
+      );
+    }
+    return;
   } catch (err) {
     backendLogger.error('Error fetching experience', { error: err.message, experienceId: req.params.id });
     return errorResponse(res, err, 'Failed to fetch experience', 400);

--- a/controllers/api/plans.js
+++ b/controllers/api/plans.js
@@ -645,13 +645,16 @@ const getPlanById = asyncHandler(async (req, res) => {
   filterNotesByVisibility(plan, req.user._id);
 
   res.json(plan);
-  setImmediate(() =>
-    refreshSignalsAndAffinity(
-      plan.experience._id.toString(),
-      req.user._id.toString(),
-      null  // experience.signals.computed_at not loaded here; treat as unknown → always refresh
-    )
-  );
+  const planExperienceId = plan.experience?._id?.toString();
+  if (planExperienceId) {
+    setImmediate(() =>
+      refreshSignalsAndAffinity(
+        planExperienceId,
+        req.user._id.toString(),
+        null  // experience.signals.computed_at not loaded here; treat as unknown → always refresh
+      )
+    );
+  }
 });
 
 /**

--- a/controllers/api/plans.js
+++ b/controllers/api/plans.js
@@ -23,7 +23,7 @@ const {
 const { insufficientPermissionsError } = require('../../utilities/error-responses');
 const crypto = require('crypto');
 const planUnplanQueue = require('../../utilities/plan-unplan-queue');
-const { updateExperienceSignals } = require('../../utilities/hidden-signals');
+const { updateExperienceSignals, refreshSignalsAndAffinity } = require('../../utilities/hidden-signals');
 
 // Sanitize location data for GeoJSON
 function sanitizeLocation(location) {
@@ -645,6 +645,13 @@ const getPlanById = asyncHandler(async (req, res) => {
   filterNotesByVisibility(plan, req.user._id);
 
   res.json(plan);
+  setImmediate(() =>
+    refreshSignalsAndAffinity(
+      plan.experience._id.toString(),
+      req.user._id.toString(),
+      null  // experience.signals.computed_at not loaded here; treat as unknown → always refresh
+    )
+  );
 });
 
 /**

--- a/models/hidden-signals.js
+++ b/models/hidden-signals.js
@@ -104,8 +104,31 @@ const contentSignalsSchema = new Schema({
   computed_at: { type: Date, default: null }
 }, { _id: false });
 
+/**
+ * A single cached affinity computation for one (user, experience) pair.
+ * Stored as a bounded array on the User document (max 50, oldest evicted).
+ */
+const affinityCacheEntrySchema = new Schema({
+  /** The experience this affinity was computed against. */
+  experience_id: { type: Schema.Types.ObjectId, required: true },
+  /** Affinity score [0, 1]. 0.5 is neutral. */
+  score: { type: Number, min: 0, max: 1, required: true },
+  /**
+   * Top 2–3 dimensions driving the match (lowest delta = strongest alignment).
+   * Empty when both vectors are below the confidence threshold.
+   */
+  top_dims: [{
+    dim:        { type: String },   // e.g. 'food_focus'
+    user_val:   { type: Number },   // user's signal value
+    entity_val: { type: Number },   // experience's signal value
+    delta:      { type: Number }    // abs(user_val - entity_val)
+  }],
+  computed_at: { type: Date, default: Date.now }
+}, { _id: false });
+
 module.exports = {
   hiddenSignalVectorSchema,
   hiddenSignalEventSchema,
-  contentSignalsSchema
+  contentSignalsSchema,
+  affinityCacheEntrySchema
 };

--- a/models/hidden-signals.js
+++ b/models/hidden-signals.js
@@ -117,12 +117,15 @@ const affinityCacheEntrySchema = new Schema({
    * Top 2–3 dimensions driving the match (lowest delta = strongest alignment).
    * Empty when both vectors are below the confidence threshold.
    */
-  top_dims: [{
-    dim:        { type: String },   // e.g. 'food_focus'
-    user_val:   { type: Number },   // user's signal value
-    entity_val: { type: Number },   // experience's signal value
-    delta:      { type: Number }    // abs(user_val - entity_val)
-  }],
+  top_dims: {
+    type: [new Schema({
+      dim:        { type: String, default: null },
+      user_val:   { type: Number, default: null },
+      entity_val: { type: Number, default: null },
+      delta:      { type: Number, default: null }
+    }, { _id: false })],
+    default: []
+  },
   computed_at: { type: Date, default: Date.now }
 }, { _id: false });
 

--- a/models/hidden-signals.js
+++ b/models/hidden-signals.js
@@ -31,8 +31,7 @@ const hiddenSignalVectorSchema = new Schema({
   cultural_depth: { type: Number, min: 0, max: 1, default: 0.5 },
   comfort_zone: { type: Number, min: 0, max: 1, default: 0.5 },
   confidence: { type: Number, min: 0, max: 1, default: 0 },
-  last_updated: { type: Date, default: null },
-  weights: { type: Map, of: Number, default: () => new Map() }
+  last_updated: { type: Date, default: null }
 }, { _id: false });
 
 /**

--- a/models/user.js
+++ b/models/user.js
@@ -9,7 +9,7 @@ const mongoose = require("mongoose");
 const Schema = mongoose.Schema;
 const bcrypt = require("bcrypt");
 const { USER_ROLES } = require("../utilities/user-roles");
-const { hiddenSignalVectorSchema, hiddenSignalEventSchema } = require('./hidden-signals');
+const { hiddenSignalVectorSchema, hiddenSignalEventSchema, affinityCacheEntrySchema } = require('./hidden-signals');
 
 /**
  * Number of salt rounds for password hashing
@@ -628,6 +628,16 @@ const userSchema = new Schema(
     hidden_signal_events: {
       type: [hiddenSignalEventSchema],
       default: []
+    },
+
+    /**
+     * Per-experience affinity cache. Capped at 50 entries; oldest evicted first.
+     * Updated fire-and-forget on experience/plan page loads.
+     * Used by BienBot context builders to avoid live DB joins.
+     */
+    affinity_cache: {
+      type: [affinityCacheEntrySchema],
+      default: () => []
     }
   },
   {

--- a/models/user.js
+++ b/models/user.js
@@ -637,7 +637,7 @@ const userSchema = new Schema(
      */
     affinity_cache: {
       type: [affinityCacheEntrySchema],
-      default: () => []
+      default: []
     }
   },
   {

--- a/src/components/DestinationWizardModal/DestinationWizardModal.jsx
+++ b/src/components/DestinationWizardModal/DestinationWizardModal.jsx
@@ -379,23 +379,44 @@ export default function DestinationWizardModal({ show, onClose, initialValues = 
   ];
 
   const renderStepIndicator = () => (
-    <Steps.Root step={currentStep} count={stepItems.length} size="sm" colorPalette="blue" px="5" pt="4" pb="2">
-      <Steps.List>
-        {stepItems.map((s) => (
-          <Steps.Item key={s.index} index={s.index}>
-            <Steps.Indicator>
-              <Steps.Status
-                complete={<FaCheck size={10} />}
-                incomplete={<Steps.Number />}
-                current={<Steps.Number />}
-              />
-            </Steps.Indicator>
-            <Steps.Title>{s.title}</Steps.Title>
-            <Steps.Separator />
-          </Steps.Item>
-        ))}
-      </Steps.List>
-    </Steps.Root>
+    <>
+      {/* Mobile/Tablet: compact dropdown */}
+      <div className={styles.stepDropdown}>
+        <select
+          className={styles.stepDropdownSelect}
+          value={currentStep}
+          disabled
+          aria-label={`Step ${currentStep + 1} of ${stepItems.length}: ${stepLabels[currentStep] ?? ''}`}
+        >
+          {stepItems.map((s) => (
+            <option key={s.index} value={s.index}>
+              {`Step ${s.index + 1} of ${stepItems.length}: ${s.title}`}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Desktop: horizontal stepper */}
+      <div className={styles.stepStepper}>
+        <Steps.Root step={currentStep} count={stepItems.length} size="sm" colorPalette="blue" px="5" pt="4" pb="2">
+          <Steps.List>
+            {stepItems.map((s) => (
+              <Steps.Item key={s.index} index={s.index}>
+                <Steps.Indicator>
+                  <Steps.Status
+                    complete={<FaCheck size={10} />}
+                    incomplete={<Steps.Number />}
+                    current={<Steps.Number />}
+                  />
+                </Steps.Indicator>
+                <Steps.Title>{s.title}</Steps.Title>
+                <Steps.Separator />
+              </Steps.Item>
+            ))}
+          </Steps.List>
+        </Steps.Root>
+      </div>
+    </>
   );
 
   const renderStep1 = () => (

--- a/src/components/DestinationWizardModal/DestinationWizardModal.module.css
+++ b/src/components/DestinationWizardModal/DestinationWizardModal.module.css
@@ -100,6 +100,40 @@
   min-height: 280px;
 }
 
+/* Step indicator: dropdown on mobile/tablet, horizontal stepper on desktop */
+.stepDropdown {
+  display: block;
+  padding: var(--space-3) var(--space-5);
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.stepDropdownSelect {
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  cursor: default;
+  appearance: auto;
+}
+
+.stepStepper {
+  display: none;
+}
+
+@media (min-width: 992px) {
+  .stepDropdown {
+    display: none;
+  }
+
+  .stepStepper {
+    display: block;
+  }
+}
+
 .stepDescription {
   color: var(--color-text-secondary);
   font-size: var(--font-size-base);

--- a/src/components/ExperienceWizardModal/ExperienceWizardModal.jsx
+++ b/src/components/ExperienceWizardModal/ExperienceWizardModal.jsx
@@ -647,23 +647,44 @@ export default function ExperienceWizardModal({ show, onClose, initialValues = {
   ];
 
   const renderStepIndicator = () => (
-    <Steps.Root step={currentStep} count={stepItems.length} size="sm" colorPalette="blue" px="5" pt="4" pb="2">
-      <Steps.List>
-        {stepItems.map((s) => (
-          <Steps.Item key={s.index} index={s.index}>
-            <Steps.Indicator>
-              <Steps.Status
-                complete={<FaCheck size={10} />}
-                incomplete={<Steps.Number />}
-                current={<Steps.Number />}
-              />
-            </Steps.Indicator>
-            <Steps.Title>{s.title}</Steps.Title>
-            <Steps.Separator />
-          </Steps.Item>
-        ))}
-      </Steps.List>
-    </Steps.Root>
+    <>
+      {/* Mobile/Tablet: compact dropdown */}
+      <div className={styles.stepDropdown}>
+        <select
+          className={styles.stepDropdownSelect}
+          value={currentStep}
+          disabled
+          aria-label={`Step ${currentStep + 1} of ${stepItems.length}: ${stepLabels[currentStep] ?? ''}`}
+        >
+          {stepItems.map((s) => (
+            <option key={s.index} value={s.index}>
+              {`Step ${s.index + 1} of ${stepItems.length}: ${s.title}`}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Desktop: horizontal stepper */}
+      <div className={styles.stepStepper}>
+        <Steps.Root step={currentStep} count={stepItems.length} size="sm" colorPalette="blue" px="5" pt="4" pb="2">
+          <Steps.List>
+            {stepItems.map((s) => (
+              <Steps.Item key={s.index} index={s.index}>
+                <Steps.Indicator>
+                  <Steps.Status
+                    complete={<FaCheck size={10} />}
+                    incomplete={<Steps.Number />}
+                    current={<Steps.Number />}
+                  />
+                </Steps.Indicator>
+                <Steps.Title>{s.title}</Steps.Title>
+                <Steps.Separator />
+              </Steps.Item>
+            ))}
+          </Steps.List>
+        </Steps.Root>
+      </div>
+    </>
   );
 
   const renderStep1 = () => (

--- a/src/components/ExperienceWizardModal/ExperienceWizardModal.module.css
+++ b/src/components/ExperienceWizardModal/ExperienceWizardModal.module.css
@@ -125,6 +125,40 @@
   }
 }
 
+/* Step indicator: dropdown on mobile/tablet, horizontal stepper on desktop */
+.stepDropdown {
+  display: block;
+  padding: var(--space-3) var(--space-5);
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.stepDropdownSelect {
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  cursor: default;
+  appearance: auto;
+}
+
+.stepStepper {
+  display: none;
+}
+
+@media (min-width: 992px) {
+  .stepDropdown {
+    display: none;
+  }
+
+  .stepStepper {
+    display: block;
+  }
+}
+
 .stepDescription {
   color: var(--color-text-secondary);
   font-size: var(--font-size-base);

--- a/tests/utils/affinity-cache.test.js
+++ b/tests/utils/affinity-cache.test.js
@@ -39,26 +39,28 @@ const mockUser = {
     };
   }),
   findByIdAndUpdate: jest.fn(async (userId, update) => {
-    // Simulate $pull (remove by experience_id) then $push with $slice
     let entries = [..._getStore(userId)];
 
-    // Handle $pull stage
-    const pull = update.$pull;
-    if (pull && pull.affinity_cache) {
-      const pullExperienceId = pull.affinity_cache.experience_id;
-      entries = entries.filter(
-        (e) => e.experience_id.toString() !== pullExperienceId.toString()
-      );
-    }
-
-    // Handle $push with $slice
-    const push = update.$push;
-    if (push && push.affinity_cache) {
-      const eachItems = push.affinity_cache.$each || [];
-      entries = [...entries, ...eachItems];
-      const slice = push.affinity_cache.$slice;
-      if (typeof slice === 'number' && slice < 0) {
-        entries = entries.slice(slice);
+    if (Array.isArray(update)) {
+      // Simulate the aggregation pipeline used by MongoAffinityCache.setAffinityEntry:
+      // [{ $set: { affinity_cache: { $slice: [{ $concatArrays: [{ $filter: ... }, [newEntry]] }, -MAX_ENTRIES] } } }]
+      const pipeline = update[0];
+      const sliceOp = pipeline?.$set?.affinity_cache?.$slice;
+      if (sliceOp) {
+        const concatOp = sliceOp[0]?.$concatArrays;
+        const maxEntries = typeof sliceOp[1] === 'number' ? Math.abs(sliceOp[1]) : 50;
+        if (concatOp) {
+          // concatOp[1] is the literal array containing the new entry
+          const newEntries = concatOp[1];
+          const newExperienceId = newEntries[0]?.experience_id?.toString();
+          // Filter out any existing entry for the same experienceId
+          const filtered = newExperienceId
+            ? entries.filter((e) => e.experience_id.toString() !== newExperienceId)
+            : entries;
+          // Append new entries and cap at MAX_ENTRIES (slice from end)
+          const combined = [...filtered, ...newEntries];
+          entries = combined.length > maxEntries ? combined.slice(-maxEntries) : combined;
+        }
       }
     }
 

--- a/tests/utils/affinity-cache.test.js
+++ b/tests/utils/affinity-cache.test.js
@@ -187,4 +187,31 @@ describe('affinity-cache (MongoDB provider)', () => {
     const map = await getAffinityMap(userId);
     expect(map.size).toBe(50);
   });
+
+  it('6. getAffinityMap excludes entries older than AFFINITY_CACHE_TTL_MS (TTL filtering)', async () => {
+    const { AFFINITY_CACHE_TTL_MS } = require('../../utilities/signals-config');
+    const userId = makeId();
+    const freshExpId = makeId();
+    const staleExpId = makeId();
+
+    // Build entries with explicit computed_at timestamps
+    const freshEntry = makeEntry(freshExpId, 0.9);
+    freshEntry.computed_at = new Date(); // within TTL
+
+    const staleEntry = makeEntry(staleExpId, 0.7);
+    staleEntry.computed_at = new Date(Date.now() - AFFINITY_CACHE_TTL_MS - 1000); // past TTL
+
+    // Directly populate the in-memory store to bypass setAffinityEntry's timestamp
+    _store[userId.toString()] = [freshEntry, staleEntry];
+
+    const map = await getAffinityMap(userId);
+
+    expect(map.size).toBe(1);
+    expect(map.has(freshExpId.toString())).toBe(true);
+    expect(map.has(staleExpId.toString())).toBe(false);
+
+    // getAffinityEntry should also return null for the stale entry
+    const staleResult = await getAffinityEntry(userId, staleExpId);
+    expect(staleResult).toBeNull();
+  });
 });

--- a/tests/utils/affinity-cache.test.js
+++ b/tests/utils/affinity-cache.test.js
@@ -1,0 +1,188 @@
+/**
+ * Tests for affinity-cache.js — MongoDB provider (mocked)
+ *
+ * Covers:
+ * 1. getAffinityEntry returns null when no entry exists
+ * 2. getAffinityEntry returns the correct entry after setAffinityEntry stores one
+ * 3. getAffinityMap returns a Map with all stored entries for a user
+ * 4. setAffinityEntry replaces an existing entry (same experienceId → updated score)
+ * 5. setAffinityEntry caps at 50 entries (push 51, verify map has 50)
+ */
+
+'use strict';
+
+const mongoose = require('mongoose');
+
+// ---------------------------------------------------------------------------
+// Mock the User model before requiring affinity-cache
+// ---------------------------------------------------------------------------
+
+// In-memory store: userId (string) → array of affinity_cache entries
+const _store = {};
+
+function _getStore(userId) {
+  return _store[userId.toString()] || [];
+}
+
+function _setStore(userId, entries) {
+  _store[userId.toString()] = entries;
+}
+
+const mockUser = {
+  findById: jest.fn((userId) => {
+    const entries = _getStore(userId);
+    const doc = { affinity_cache: entries };
+    return {
+      select: () => ({
+        lean: async () => doc
+      })
+    };
+  }),
+  findByIdAndUpdate: jest.fn(async (userId, update) => {
+    // Simulate $pull (remove by experience_id) then $push with $slice
+    let entries = [..._getStore(userId)];
+
+    // Handle $pull stage
+    const pull = update.$pull;
+    if (pull && pull.affinity_cache) {
+      const pullExperienceId = pull.affinity_cache.experience_id;
+      entries = entries.filter(
+        (e) => e.experience_id.toString() !== pullExperienceId.toString()
+      );
+    }
+
+    // Handle $push with $slice
+    const push = update.$push;
+    if (push && push.affinity_cache) {
+      const eachItems = push.affinity_cache.$each || [];
+      entries = [...entries, ...eachItems];
+      const slice = push.affinity_cache.$slice;
+      if (typeof slice === 'number' && slice < 0) {
+        entries = entries.slice(slice);
+      }
+    }
+
+    _setStore(userId, entries);
+    return null;
+  })
+};
+
+jest.mock('../../models/user', () => mockUser);
+
+// ---------------------------------------------------------------------------
+// Now require the module under test
+// ---------------------------------------------------------------------------
+
+const {
+  getAffinityEntry,
+  setAffinityEntry,
+  getAffinityMap,
+  resetAffinityCache,
+  createAffinityCache
+} = require('../../utilities/affinity-cache');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeId() {
+  return new mongoose.Types.ObjectId();
+}
+
+function makeEntry(experienceId, score = 0.8) {
+  return {
+    experience_id: experienceId,
+    score,
+    top_dims: [{ dim: 'energy', user_val: 0.7, entity_val: 0.6, delta: 0.1 }],
+    computed_at: new Date()
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  // Clear in-memory mock store
+  Object.keys(_store).forEach((k) => delete _store[k]);
+  // Clear Jest mock call history
+  mockUser.findById.mockClear();
+  mockUser.findByIdAndUpdate.mockClear();
+  // Reset singleton so each test gets a fresh MongoAffinityCache instance
+  resetAffinityCache();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('affinity-cache (MongoDB provider)', () => {
+  it('1. getAffinityEntry returns null when no entry exists for that experienceId', async () => {
+    const userId = makeId();
+    const experienceId = makeId();
+
+    const result = await getAffinityEntry(userId, experienceId);
+
+    expect(result).toBeNull();
+  });
+
+  it('2. getAffinityEntry returns the correct entry after setAffinityEntry stores one', async () => {
+    const userId = makeId();
+    const experienceId = makeId();
+    const entry = makeEntry(experienceId, 0.75);
+
+    await setAffinityEntry(userId, experienceId, entry);
+    const result = await getAffinityEntry(userId, experienceId);
+
+    expect(result).not.toBeNull();
+    expect(result.score).toBe(0.75);
+    expect(result.experience_id.toString()).toBe(experienceId.toString());
+  });
+
+  it('3. getAffinityMap returns a Map with all stored entries for a user', async () => {
+    const userId = makeId();
+    const expId1 = makeId();
+    const expId2 = makeId();
+    const expId3 = makeId();
+
+    await setAffinityEntry(userId, expId1, makeEntry(expId1, 0.9));
+    await setAffinityEntry(userId, expId2, makeEntry(expId2, 0.7));
+    await setAffinityEntry(userId, expId3, makeEntry(expId3, 0.5));
+
+    const map = await getAffinityMap(userId);
+
+    expect(map).toBeInstanceOf(Map);
+    expect(map.size).toBe(3);
+    expect(map.get(expId1.toString()).score).toBe(0.9);
+    expect(map.get(expId2.toString()).score).toBe(0.7);
+    expect(map.get(expId3.toString()).score).toBe(0.5);
+  });
+
+  it('4. setAffinityEntry replaces an existing entry (same experienceId → updated score)', async () => {
+    const userId = makeId();
+    const experienceId = makeId();
+
+    await setAffinityEntry(userId, experienceId, makeEntry(experienceId, 0.6));
+    await setAffinityEntry(userId, experienceId, makeEntry(experienceId, 0.95));
+
+    const result = await getAffinityEntry(userId, experienceId);
+    expect(result.score).toBe(0.95);
+
+    // Should still be exactly one entry for this experienceId
+    const map = await getAffinityMap(userId);
+    expect(map.size).toBe(1);
+  });
+
+  it('5. setAffinityEntry caps at 50 entries (push 51, verify map has 50)', async () => {
+    const userId = makeId();
+
+    // Push 51 distinct experience entries
+    for (let i = 0; i < 51; i++) {
+      const expId = makeId();
+      await setAffinityEntry(userId, expId, makeEntry(expId, i / 51));
+    }
+
+    const map = await getAffinityMap(userId);
+    expect(map.size).toBe(50);
+  });
+});

--- a/tests/utils/bienbot-context-affinity.test.js
+++ b/tests/utils/bienbot-context-affinity.test.js
@@ -178,4 +178,69 @@ describe('appendAffinityBlock (via buildContextForInvokeContext)', () => {
     expect(result).toContain('[AFFINITY]');
     expect(result).toContain('moderate alignment');
   });
+
+  test('does not throw and omits [AFFINITY] when affinityCache.getAffinityEntry throws', async () => {
+    // appendAffinityBlock wraps in try/catch — errors must be swallowed
+    affinityCache.getAffinityEntry.mockRejectedValue(new Error('Redis connection lost'));
+
+    // Should not throw
+    await expect(
+      buildContextForInvokeContext(invokeCtx, VALID_USER_ID)
+    ).resolves.not.toThrow();
+
+    // [AFFINITY] block must be absent (error was swallowed)
+    const result = await buildContextForInvokeContext(invokeCtx, VALID_USER_ID);
+    expect(result).not.toContain('[AFFINITY]');
+  });
+
+  test('appends [AFFINITY] for plan entity when experience is resolvable from plan doc', async () => {
+    const Plan = require('../../models/plan');
+
+    const VALID_PLAN_ID = '64f1234567890abcdef12388';
+
+    // First call: buildUserPlanContext calls Plan.findById(planOid).populate(...)
+    const mockPlanDoc = {
+      _id: { toString: () => VALID_PLAN_ID },
+      experience: { _id: { toString: () => VALID_EXPERIENCE_ID }, name: 'Test Experience' },
+      plan: [],
+      permissions: [{ entity: 'user', _id: VALID_USER_ID, type: 'owner' }],
+      planned_date: null,
+      currency: null,
+      costs: [],
+    };
+
+    // Second call: buildContextForInvokeContext calls Plan.findById(id).select('experience').lean()
+    // to resolve planExperienceId for the affinity block
+    let callCount = 0;
+    Plan.findById.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // buildUserPlanContext: .populate(...)
+        return { populate: jest.fn().mockResolvedValue(mockPlanDoc) };
+      }
+      // affinity resolution: .select('experience').lean()
+      return {
+        select: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue({ experience: VALID_EXPERIENCE_ID }),
+        }),
+      };
+    });
+
+    affinityCache.getAffinityEntry.mockResolvedValue({
+      score: 0.78,
+      top_dims: [{ dim: 'adventure' }],
+    });
+
+    const planInvokeCtx = {
+      entity: 'plan',
+      entity_id: VALID_PLAN_ID,
+      entity_label: 'Test Plan',
+    };
+
+    const result = await buildContextForInvokeContext(planInvokeCtx, VALID_USER_ID);
+
+    // Plan path must resolve experience ID and append [AFFINITY]
+    expect(result).toContain('[AFFINITY]');
+    expect(result).toContain('strong alignment');
+  });
 });

--- a/tests/utils/bienbot-context-affinity.test.js
+++ b/tests/utils/bienbot-context-affinity.test.js
@@ -1,0 +1,181 @@
+'use strict';
+
+/**
+ * Tests for the appendAffinityBlock behaviour in bienbot-context-builders.
+ *
+ * appendAffinityBlock is a local (unexported) helper, so we test it indirectly
+ * by mocking affinityCache and calling buildContextForInvokeContext with
+ * entity === 'experience'. The [AFFINITY] line should appear (or not) in the
+ * returned string based on the cache entry.
+ */
+
+jest.mock('../../utilities/affinity-cache');
+jest.mock('../../utilities/permission-enforcer', () => ({
+  getEnforcer: () => ({
+    canView: jest.fn().mockResolvedValue({ allowed: true }),
+  }),
+}));
+jest.mock('../../utilities/controller-helpers', () => ({
+  validateObjectId: (id) => ({ valid: !!id && id.length >= 24, objectId: id }),
+}));
+jest.mock('../../utilities/fuzzy-match', () => ({ findSimilarItems: jest.fn() }));
+jest.mock('../../utilities/hidden-signals', () => ({
+  aggregateGroupSignals: jest.fn(),
+  applySignalDecay: jest.fn(s => s),
+  signalsToNaturalLanguage: jest.fn(() => null),
+  computePopularityScore: jest.fn(() => 0.5),
+  computeAffinityScore: jest.fn(() => 0.5),
+}));
+jest.mock('../../utilities/signals-config', () => ({
+  formula: { adaptiveFactor: 0.4, trustScore: 0.2, popularity: 0.2, recencyBoost: 0.1, affinity: 0.1 },
+}));
+jest.mock('../../utilities/backend-logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+}));
+
+// Minimal Experience model mock
+const mockExperience = {
+  _id: '64f1234567890abcdef12345',
+  name: 'Test Experience',
+  destination: { _id: '64f1234567890abcdef12346', name: 'Test Destination' },
+  plan_items: [],
+  overview: null,
+  experience_type: [],
+  difficulty: null,
+  rating: null,
+  visibility: null,
+  signal_tags: [],
+  cost_estimate: 0,
+  max_planning_days: 1,
+};
+
+jest.mock('../../models/experience', () => ({
+  findById: jest.fn().mockReturnValue({
+    populate: jest.fn().mockResolvedValue(mockExperience),
+  }),
+}));
+jest.mock('../../models/plan', () => ({
+  findById: jest.fn().mockReturnValue({
+    select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(null) }),
+  }),
+  findOne: jest.fn().mockReturnValue({
+    select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(null) }),
+    populate: jest.fn().mockReturnValue({ select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }) }),
+  }),
+  find: jest.fn().mockReturnValue({
+    populate: jest.fn().mockReturnValue({ select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }) }),
+    select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }),
+  }),
+}));
+jest.mock('../../models/destination', () => ({}));
+jest.mock('../../models/user', () => ({
+  findById: jest.fn().mockReturnValue({
+    select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(null) }),
+  }),
+  find: jest.fn().mockReturnValue({
+    select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }),
+  }),
+}));
+jest.mock('../../models/activity', () => ({}));
+
+const affinityCache = require('../../utilities/affinity-cache');
+const { buildContextForInvokeContext } = require('../../utilities/bienbot-context-builders');
+
+const VALID_EXPERIENCE_ID = '64f1234567890abcdef12345';
+const VALID_USER_ID = '64f1234567890abcdef12399';
+
+const invokeCtx = {
+  entity: 'experience',
+  entity_id: VALID_EXPERIENCE_ID,
+  entity_label: 'Test Experience',
+};
+
+describe('appendAffinityBlock (via buildContextForInvokeContext)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('appends [AFFINITY] line when score is 0.82 with 2 top_dims (strong alignment)', async () => {
+    affinityCache.getAffinityEntry.mockResolvedValue({
+      score: 0.82,
+      top_dims: [{ dim: 'adventure' }, { dim: 'outdoor' }],
+    });
+
+    const result = await buildContextForInvokeContext(invokeCtx, VALID_USER_ID);
+
+    expect(result).toContain('[AFFINITY]');
+    expect(result).toContain('0.82');
+    expect(result).toContain('strong alignment');
+    expect(result).toContain('adventure');
+    expect(result).toContain('outdoor');
+  });
+
+  test('does NOT append [AFFINITY] when score is 0.52 (within ±0.05 of neutral 0.5)', async () => {
+    affinityCache.getAffinityEntry.mockResolvedValue({
+      score: 0.52,
+      top_dims: [{ dim: 'adventure' }],
+    });
+
+    const result = await buildContextForInvokeContext(invokeCtx, VALID_USER_ID);
+
+    expect(result).not.toContain('[AFFINITY]');
+  });
+
+  test('does NOT append [AFFINITY] when entry is null (cache miss)', async () => {
+    affinityCache.getAffinityEntry.mockResolvedValue(null);
+
+    const result = await buildContextForInvokeContext(invokeCtx, VALID_USER_ID);
+
+    expect(result).not.toContain('[AFFINITY]');
+  });
+
+  test('does NOT append [AFFINITY] when top_dims is empty', async () => {
+    affinityCache.getAffinityEntry.mockResolvedValue({
+      score: 0.82,
+      top_dims: [],
+    });
+
+    const result = await buildContextForInvokeContext(invokeCtx, VALID_USER_ID);
+
+    expect(result).not.toContain('[AFFINITY]');
+  });
+
+  test('uses "strong alignment" label for score > 0.6', async () => {
+    affinityCache.getAffinityEntry.mockResolvedValue({
+      score: 0.75,
+      top_dims: [{ dim: 'cultural' }],
+    });
+
+    const result = await buildContextForInvokeContext(invokeCtx, VALID_USER_ID);
+
+    expect(result).toContain('strong alignment');
+  });
+
+  test('uses "low alignment" label for score < 0.4', async () => {
+    affinityCache.getAffinityEntry.mockResolvedValue({
+      score: 0.25,
+      top_dims: [{ dim: 'nightlife' }],
+    });
+
+    const result = await buildContextForInvokeContext(invokeCtx, VALID_USER_ID);
+
+    expect(result).toContain('[AFFINITY]');
+    expect(result).toContain('low alignment');
+  });
+
+  test('uses "moderate alignment" label for score in 0.4–0.6 range (but > ±0.05 from neutral)', async () => {
+    // score = 0.42: abs(0.42 - 0.5) = 0.08 > 0.05, and 0.4 <= 0.42 <= 0.6
+    affinityCache.getAffinityEntry.mockResolvedValue({
+      score: 0.42,
+      top_dims: [{ dim: 'wellness' }],
+    });
+
+    const result = await buildContextForInvokeContext(invokeCtx, VALID_USER_ID);
+
+    expect(result).toContain('[AFFINITY]');
+    expect(result).toContain('moderate alignment');
+  });
+});

--- a/tests/utils/hidden-signals-affinity.test.js
+++ b/tests/utils/hidden-signals-affinity.test.js
@@ -291,16 +291,17 @@ describe('refreshSignalsAndAffinity', () => {
   });
 
   test('7. never throws even if computeAndCacheAffinity rejects', async () => {
-    // Make user lookup fail so computeAndCacheAffinity will log a warning and return early
-    // But more directly: make affinityCache.setAffinityEntry reject
+    // Force affinityCache.setAffinityEntry to reject so we exercise the rejection path
     const affinityCache = require('../../utilities/affinity-cache');
     affinityCache.setAffinityEntry.mockRejectedValueOnce(new Error('Cache write failure'));
 
-    // computedAt is null so staleness check will call updateExperienceSignals too
-    // We need models to work for the test but setAffinityEntry to fail
-    // refreshSignalsAndAffinity should still not throw
+    // computedAt is null → staleness check triggers updateExperienceSignals before compute
+    // refreshSignalsAndAffinity should still not throw even if the cache write fails
     await expect(
       refreshSignalsAndAffinity(VALID_EXPERIENCE_ID, VALID_USER_ID, null)
     ).resolves.not.toThrow();
+
+    // Confirm the failing cache write path was actually exercised
+    expect(affinityCache.setAffinityEntry).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/utils/hidden-signals-affinity.test.js
+++ b/tests/utils/hidden-signals-affinity.test.js
@@ -1,0 +1,306 @@
+/**
+ * Tests for hidden-signals.js — computeAndCacheAffinity and refreshSignalsAndAffinity
+ *
+ * Covers:
+ * 1. computeAndCacheAffinity calls affinityCache.setAffinityEntry with a valid entry
+ *    when both user and experience have hidden_signals
+ * 2. computeAndCacheAffinity returns early without calling setAffinityEntry when
+ *    userId is invalid
+ * 3. computeAndCacheAffinity returns early without calling setAffinityEntry when
+ *    user not found
+ * 4. computeAndCacheAffinity top_dims contains only dimensions where delta < 0.3,
+ *    sorted ascending by delta
+ * 5. refreshSignalsAndAffinity calls updateExperienceSignals when computedAt is null
+ * 6. refreshSignalsAndAffinity does NOT call updateExperienceSignals when computedAt
+ *    is fresh (within SIGNALS_STALENESS_MS)
+ * 7. refreshSignalsAndAffinity never throws even if computeAndCacheAffinity rejects
+ */
+
+'use strict';
+
+const mongoose = require('mongoose');
+
+// ---------------------------------------------------------------------------
+// Mock affinityCache module before requiring hidden-signals
+// ---------------------------------------------------------------------------
+
+const mockSetAffinityEntry = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../../utilities/affinity-cache', () => ({
+  setAffinityEntry: mockSetAffinityEntry,
+  getAffinityEntry: jest.fn().mockResolvedValue(null),
+  getAffinityMap: jest.fn().mockResolvedValue(new Map()),
+  resetAffinityCache: jest.fn(),
+  createAffinityCache: jest.fn()
+}));
+
+// ---------------------------------------------------------------------------
+// Mock models
+// ---------------------------------------------------------------------------
+
+const VALID_USER_ID = new mongoose.Types.ObjectId().toString();
+const VALID_EXPERIENCE_ID = new mongoose.Types.ObjectId().toString();
+
+const defaultUserSignals = {
+  energy: 0.8,
+  novelty: 0.6,
+  budget_sensitivity: 0.4,
+  social: 0.7,
+  structure: 0.5,
+  food_focus: 0.3,
+  cultural_depth: 0.6,
+  comfort_zone: 0.4,
+  confidence: 0.9,
+  last_updated: new Date(Date.now() - 60 * 60 * 1000) // 1 hour ago (triggers decay check but minimal decay)
+};
+
+const defaultExperienceSignals = {
+  energy: 0.7,
+  novelty: 0.5,
+  budget_sensitivity: 0.3,
+  social: 0.6,
+  structure: 0.5,
+  food_focus: 0.4,
+  cultural_depth: 0.7,
+  comfort_zone: 0.5,
+  confidence: 0.8,
+  last_updated: new Date(Date.now() - 60 * 60 * 1000)
+};
+
+const mockUserFindById = jest.fn();
+const mockExperienceFindById = jest.fn();
+
+jest.mock('../../models/user', () => ({
+  findById: (...args) => mockUserFindById(...args)
+}));
+
+jest.mock('../../models/experience', () => ({
+  findById: (...args) => mockExperienceFindById(...args),
+  findByIdAndUpdate: jest.fn().mockResolvedValue(null)
+}));
+
+// Also mock plan model (required by updateExperienceSignals)
+jest.mock('../../models/plan', () => ({
+  aggregate: jest.fn().mockResolvedValue([{
+    planCount: 5,
+    planCountWithActivity: 3,
+    completedPlanCount: 2
+  }])
+}));
+
+// Mock feature-flags (required by updateExperienceSignals)
+jest.mock('../../utilities/feature-flags', () => ({
+  hasFeatureFlag: jest.fn().mockReturnValue(false)
+}));
+
+// ---------------------------------------------------------------------------
+// Set up default mock implementations
+// ---------------------------------------------------------------------------
+
+function setupDefaultMocks() {
+  mockUserFindById.mockReturnValue({
+    select: () => ({
+      lean: async () => ({
+        _id: new mongoose.Types.ObjectId(VALID_USER_ID),
+        hidden_signals: { ...defaultUserSignals }
+      })
+    })
+  });
+
+  mockExperienceFindById.mockReturnValue({
+    select: () => ({
+      lean: async () => ({
+        _id: new mongoose.Types.ObjectId(VALID_EXPERIENCE_ID),
+        hidden_signals: { ...defaultExperienceSignals },
+        user: new mongoose.Types.ObjectId(),
+        public: true,
+        plan_items: []
+      })
+    })
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Require the module under test (after mocks are set up)
+// ---------------------------------------------------------------------------
+
+const {
+  computeAndCacheAffinity,
+  refreshSignalsAndAffinity,
+  updateExperienceSignals: _updateExperienceSignals
+} = require('../../utilities/hidden-signals');
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('computeAndCacheAffinity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  test('1. calls setAffinityEntry with a valid entry when both user and experience have hidden_signals', async () => {
+    await computeAndCacheAffinity(VALID_USER_ID, VALID_EXPERIENCE_ID);
+
+    expect(mockSetAffinityEntry).toHaveBeenCalledTimes(1);
+
+    const [calledUserId, calledExperienceId, entry] = mockSetAffinityEntry.mock.calls[0];
+
+    expect(calledUserId.toString()).toBe(VALID_USER_ID.toString());
+    expect(calledExperienceId.toString()).toBe(VALID_EXPERIENCE_ID.toString());
+
+    // Validate entry shape
+    expect(entry).toHaveProperty('experience_id');
+    expect(entry).toHaveProperty('score');
+    expect(entry).toHaveProperty('top_dims');
+    expect(entry).toHaveProperty('computed_at');
+    expect(typeof entry.score).toBe('number');
+    expect(entry.score).toBeGreaterThanOrEqual(0);
+    expect(entry.score).toBeLessThanOrEqual(1);
+    expect(Array.isArray(entry.top_dims)).toBe(true);
+    expect(entry.computed_at).toBeInstanceOf(Date);
+  });
+
+  test('2. returns early without calling setAffinityEntry when userId is invalid', async () => {
+    await computeAndCacheAffinity('not-a-valid-objectid', VALID_EXPERIENCE_ID);
+    expect(mockSetAffinityEntry).not.toHaveBeenCalled();
+  });
+
+  test('3. returns early without calling setAffinityEntry when user not found', async () => {
+    mockUserFindById.mockReturnValue({
+      select: () => ({
+        lean: async () => null
+      })
+    });
+
+    await computeAndCacheAffinity(VALID_USER_ID, VALID_EXPERIENCE_ID);
+    expect(mockSetAffinityEntry).not.toHaveBeenCalled();
+  });
+
+  test('4. top_dims contains only dimensions where delta < 0.3, sorted ascending by delta', async () => {
+    // Set up signals where some dimensions have large deltas (>= 0.3) and some have small deltas (< 0.3)
+    mockUserFindById.mockReturnValue({
+      select: () => ({
+        lean: async () => ({
+          _id: new mongoose.Types.ObjectId(VALID_USER_ID),
+          hidden_signals: {
+            energy: 0.9,           // delta with experience: |0.9 - 0.2| = 0.7 → excluded
+            novelty: 0.5,          // delta: |0.5 - 0.5| = 0.0 → included (dim 1, lowest delta)
+            budget_sensitivity: 0.5, // delta: |0.5 - 0.6| = 0.1 → included (dim 2)
+            social: 0.5,           // delta: |0.5 - 0.65| = 0.15 → included (dim 3)
+            structure: 0.5,        // delta: |0.5 - 0.8| = 0.3 → excluded (not < 0.3)
+            food_focus: 0.9,       // delta: |0.9 - 0.1| = 0.8 → excluded
+            cultural_depth: 0.5,   // delta: |0.5 - 0.5| = 0.0 → included (but only top 3)
+            comfort_zone: 0.9,     // delta: |0.9 - 0.1| = 0.8 → excluded
+            confidence: 0.9,
+            last_updated: new Date(Date.now() - 60 * 60 * 1000)
+          }
+        })
+      })
+    });
+
+    mockExperienceFindById.mockReturnValue({
+      select: () => ({
+        lean: async () => ({
+          _id: new mongoose.Types.ObjectId(VALID_EXPERIENCE_ID),
+          hidden_signals: {
+            energy: 0.2,
+            novelty: 0.5,
+            budget_sensitivity: 0.6,
+            social: 0.65,
+            structure: 0.8,
+            food_focus: 0.1,
+            cultural_depth: 0.5,
+            comfort_zone: 0.1,
+            confidence: 0.9,
+            last_updated: new Date(Date.now() - 60 * 60 * 1000)
+          }
+        })
+      })
+    });
+
+    await computeAndCacheAffinity(VALID_USER_ID, VALID_EXPERIENCE_ID);
+
+    expect(mockSetAffinityEntry).toHaveBeenCalledTimes(1);
+    const entry = mockSetAffinityEntry.mock.calls[0][2];
+    const topDims = entry.top_dims;
+
+    // All top_dims must have delta < 0.3
+    for (const td of topDims) {
+      expect(td.delta).toBeLessThan(0.3);
+    }
+
+    // Must have required fields
+    for (const td of topDims) {
+      expect(td).toHaveProperty('dim');
+      expect(td).toHaveProperty('user_val');
+      expect(td).toHaveProperty('entity_val');
+      expect(td).toHaveProperty('delta');
+    }
+
+    // Must be sorted ascending by delta
+    for (let i = 1; i < topDims.length; i++) {
+      expect(topDims[i].delta).toBeGreaterThanOrEqual(topDims[i - 1].delta);
+    }
+
+    // Must contain at most 3 items
+    expect(topDims.length).toBeLessThanOrEqual(3);
+
+    // Dimensions with large deltas (energy, food_focus, comfort_zone) must NOT be included
+    const dimNames = topDims.map(td => td.dim);
+    expect(dimNames).not.toContain('energy');
+    expect(dimNames).not.toContain('food_focus');
+    expect(dimNames).not.toContain('comfort_zone');
+    // structure has delta exactly 0.3, which is not < 0.3, so it should be excluded
+    expect(dimNames).not.toContain('structure');
+  });
+});
+
+describe('refreshSignalsAndAffinity', () => {
+  // We need to spy on updateExperienceSignals which is an internal function.
+  // We'll verify its side effects via the mocked models.
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  test('5. calls updateExperienceSignals when computedAt is null (always stale)', async () => {
+    const Experience = require('../../models/experience');
+    const experienceFindByIdAndUpdateSpy = jest.spyOn(Experience, 'findByIdAndUpdate');
+
+    await refreshSignalsAndAffinity(VALID_EXPERIENCE_ID, VALID_USER_ID, null);
+
+    // updateExperienceSignals writes to Experience.findByIdAndUpdate
+    expect(experienceFindByIdAndUpdateSpy).toHaveBeenCalled();
+  });
+
+  test('6. does NOT call updateExperienceSignals when computedAt is fresh (within SIGNALS_STALENESS_MS)', async () => {
+    const config = require('../../utilities/signals-config');
+    const Experience = require('../../models/experience');
+    const experienceFindByIdAndUpdateSpy = jest.spyOn(Experience, 'findByIdAndUpdate');
+
+    // computedAt = right now (fresh, within staleness window)
+    const freshComputedAt = new Date(Date.now() - (config.SIGNALS_STALENESS_MS / 2));
+
+    await refreshSignalsAndAffinity(VALID_EXPERIENCE_ID, VALID_USER_ID, freshComputedAt);
+
+    // updateExperienceSignals should NOT have been called (signals are fresh)
+    expect(experienceFindByIdAndUpdateSpy).not.toHaveBeenCalled();
+  });
+
+  test('7. never throws even if computeAndCacheAffinity rejects', async () => {
+    // Make user lookup fail so computeAndCacheAffinity will log a warning and return early
+    // But more directly: make affinityCache.setAffinityEntry reject
+    const affinityCache = require('../../utilities/affinity-cache');
+    affinityCache.setAffinityEntry.mockRejectedValueOnce(new Error('Cache write failure'));
+
+    // computedAt is null so staleness check will call updateExperienceSignals too
+    // We need models to work for the test but setAffinityEntry to fail
+    // refreshSignalsAndAffinity should still not throw
+    await expect(
+      refreshSignalsAndAffinity(VALID_EXPERIENCE_ID, VALID_USER_ID, null)
+    ).resolves.not.toThrow();
+  });
+});

--- a/tests/utils/signals-config.test.js
+++ b/tests/utils/signals-config.test.js
@@ -1,0 +1,37 @@
+/**
+ * Tests for signals-config scalar keys (SIGNALS_STALENESS_MS, AFFINITY_CACHE_TTL_MS).
+ * These are top-level scalars, not weight groups — they must NOT be normalised.
+ */
+
+describe('signals-config scalar keys', () => {
+  let config;
+
+  beforeEach(() => {
+    jest.resetModules();
+    delete process.env.SIGNALS_CONFIG;
+    config = require('../../utilities/signals-config');
+  });
+
+  test('exports SIGNALS_STALENESS_MS with default 15 minutes', () => {
+    expect(config.SIGNALS_STALENESS_MS).toBe(15 * 60 * 1000);
+  });
+
+  test('exports AFFINITY_CACHE_TTL_MS with default 6 hours', () => {
+    expect(config.AFFINITY_CACHE_TTL_MS).toBe(6 * 60 * 60 * 1000);
+  });
+
+  test('SIGNALS_CONFIG env override applies to scalar keys', () => {
+    jest.resetModules();
+    process.env.SIGNALS_CONFIG = JSON.stringify({ SIGNALS_STALENESS_MS: 60000 });
+    const overridden = require('../../utilities/signals-config');
+    expect(overridden.SIGNALS_STALENESS_MS).toBe(60000);
+    delete process.env.SIGNALS_CONFIG;
+  });
+
+  test('scalar keys are NOT normalised (values preserved as-is)', () => {
+    // If normalised as a weight group, the value would be 1.0 (sum normalised).
+    // Check they retain their millisecond values.
+    expect(config.SIGNALS_STALENESS_MS).toBeGreaterThan(1000);
+    expect(config.AFFINITY_CACHE_TTL_MS).toBeGreaterThan(1000);
+  });
+});

--- a/tests/utils/signals-config.test.js
+++ b/tests/utils/signals-config.test.js
@@ -34,4 +34,16 @@ describe('signals-config scalar keys', () => {
     expect(config.SIGNALS_STALENESS_MS).toBeGreaterThan(1000);
     expect(config.AFFINITY_CACHE_TTL_MS).toBeGreaterThan(1000);
   });
+
+  test('invalid scalar override falls back to default', () => {
+    jest.resetModules();
+    process.env.SIGNALS_CONFIG = JSON.stringify({
+      SIGNALS_STALENESS_MS: 0,
+      AFFINITY_CACHE_TTL_MS: -1,
+    });
+    const config = require('../../utilities/signals-config');
+    expect(config.SIGNALS_STALENESS_MS).toBe(15 * 60 * 1000);
+    expect(config.AFFINITY_CACHE_TTL_MS).toBe(6 * 60 * 60 * 1000);
+    delete process.env.SIGNALS_CONFIG;
+  });
 });

--- a/utilities/affinity-cache.js
+++ b/utilities/affinity-cache.js
@@ -1,0 +1,349 @@
+/**
+ * Affinity cache provider abstraction.
+ *
+ * Provides Redis (primary) and MongoDB (fallback) cache implementations
+ * for storing pre-computed user ↔ experience affinity scores so BienBot
+ * does not recompute them live on every call.
+ *
+ * Key schema (Redis):  `bien:affinity:{userId}`  → JSON array of all cache
+ *                       entries for that user (capped at 50 most recent).
+ * Storage schema (MongoDB): User.affinity_cache  → bounded subdocument array.
+ *
+ * Provider selection: REDIS_URL present → Redis, else MongoDB.
+ *
+ * @module utilities/affinity-cache
+ */
+
+'use strict';
+
+const logger = require('./backend-logger');
+const { AFFINITY_CACHE_TTL_MS } = require('./signals-config');
+
+// Maximum number of affinity entries to keep per user.
+const MAX_ENTRIES = 50;
+
+// ---------------------------------------------------------------------------
+// MongoDB provider
+// ---------------------------------------------------------------------------
+
+class MongoAffinityCache {
+  constructor() {
+    this._User = null;
+  }
+
+  _getUser() {
+    if (!this._User) {
+      this._User = require('../models/user');
+    }
+    return this._User;
+  }
+
+  /**
+   * Build a Map<experienceIdString, entry> for a given user.
+   *
+   * @param {string|ObjectId} userId
+   * @returns {Promise<Map<string, Object>>}
+   */
+  async getAffinityMap(userId) {
+    try {
+      const User = this._getUser();
+      const user = await User.findById(userId).select('affinity_cache').lean();
+      if (!user || !Array.isArray(user.affinity_cache)) return new Map();
+
+      const map = new Map();
+      for (const entry of user.affinity_cache) {
+        map.set(entry.experience_id.toString(), entry);
+      }
+      return map;
+    } catch (err) {
+      logger.warn('[affinity-cache] MongoDB getAffinityMap failed', {
+        userId: userId.toString(),
+        error: err.message
+      });
+      return new Map();
+    }
+  }
+
+  /**
+   * Retrieve a single affinity entry for (userId, experienceId).
+   *
+   * @param {string|ObjectId} userId
+   * @param {string|ObjectId} experienceId
+   * @returns {Promise<Object|null>}
+   */
+  async getAffinityEntry(userId, experienceId) {
+    try {
+      const map = await this.getAffinityMap(userId);
+      return map.get(experienceId.toString()) || null;
+    } catch (err) {
+      logger.warn('[affinity-cache] MongoDB getAffinityEntry failed', {
+        userId: userId.toString(),
+        experienceId: experienceId.toString(),
+        error: err.message
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Store or replace an affinity entry for (userId, experienceId).
+   * Removes any existing entry with the same experienceId before pushing,
+   * then caps the array at MAX_ENTRIES (keeping the most recent).
+   *
+   * @param {string|ObjectId} userId
+   * @param {string|ObjectId} experienceId
+   * @param {Object} entry - affinityCacheEntry-shaped object
+   * @returns {Promise<void>}
+   */
+  async setAffinityEntry(userId, experienceId, entry) {
+    try {
+      const User = this._getUser();
+      // Step 1: remove existing entry for this experienceId (MongoDB does not
+      // support upsert on subdocument array fields by a nested key).
+      await User.findByIdAndUpdate(userId, {
+        $pull: { affinity_cache: { experience_id: experienceId } }
+      });
+      // Step 2: push new entry with $slice to enforce the cap.
+      await User.findByIdAndUpdate(userId, {
+        $push: {
+          affinity_cache: {
+            $each: [entry],
+            $slice: -MAX_ENTRIES
+          }
+        }
+      });
+    } catch (err) {
+      logger.warn('[affinity-cache] MongoDB setAffinityEntry failed', {
+        userId: userId.toString(),
+        experienceId: experienceId.toString(),
+        error: err.message
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Redis provider (primary)
+// ---------------------------------------------------------------------------
+
+class RedisAffinityCache {
+  constructor(redisUrl) {
+    this._redisUrl = redisUrl;
+    this._client = null;
+    this._connecting = false;
+    this._fallback = new MongoAffinityCache();
+  }
+
+  /**
+   * Build the Redis key for a user's affinity entries.
+   *
+   * @param {string|ObjectId} userId
+   * @returns {string}
+   */
+  _key(userId) {
+    return `bien:affinity:${userId.toString()}`;
+  }
+
+  async _getClient() {
+    if (this._client) return this._client;
+    if (this._connecting) return null;
+    this._connecting = true;
+    try {
+      const Redis = require('ioredis');
+      const client = new Redis(this._redisUrl, {
+        maxRetriesPerRequest: 1,
+        lazyConnect: true,
+        connectTimeout: 3000,
+        retryStrategy: (times) => (times > 3 ? null : Math.min(times * 200, 2000))
+      });
+      await client.connect();
+      logger.info('[affinity-cache] Redis cache connected');
+      client.on('error', (err) => {
+        logger.warn('[affinity-cache] Redis error, will fallback to MongoDB', {
+          error: err.message
+        });
+        this._client = null;
+        this._connecting = false;
+      });
+      this._client = client;
+      return this._client;
+    } catch (err) {
+      logger.warn('[affinity-cache] Redis connection failed, using MongoDB fallback', {
+        error: err.message
+      });
+      this._client = null;
+      this._connecting = false;
+      return null;
+    }
+  }
+
+  /**
+   * Build a Map<experienceIdString, entry> from Redis for a given user.
+   *
+   * @param {string|ObjectId} userId
+   * @returns {Promise<Map<string, Object>>}
+   */
+  async getAffinityMap(userId) {
+    const client = await this._getClient();
+    if (!client) return this._fallback.getAffinityMap(userId);
+    try {
+      const raw = await client.get(this._key(userId));
+      if (!raw) return new Map();
+      const entries = JSON.parse(raw);
+      const map = new Map();
+      for (const entry of entries) {
+        map.set(entry.experience_id.toString(), entry);
+      }
+      return map;
+    } catch (err) {
+      logger.warn('[affinity-cache] Redis getAffinityMap failed, falling back to MongoDB', {
+        userId: userId.toString(),
+        error: err.message
+      });
+      return this._fallback.getAffinityMap(userId);
+    }
+  }
+
+  /**
+   * Retrieve a single affinity entry for (userId, experienceId) from Redis.
+   *
+   * @param {string|ObjectId} userId
+   * @param {string|ObjectId} experienceId
+   * @returns {Promise<Object|null>}
+   */
+  async getAffinityEntry(userId, experienceId) {
+    const client = await this._getClient();
+    if (!client) return this._fallback.getAffinityEntry(userId, experienceId);
+    try {
+      const map = await this.getAffinityMap(userId);
+      return map.get(experienceId.toString()) || null;
+    } catch (err) {
+      logger.warn('[affinity-cache] Redis getAffinityEntry failed, falling back to MongoDB', {
+        userId: userId.toString(),
+        experienceId: experienceId.toString(),
+        error: err.message
+      });
+      return this._fallback.getAffinityEntry(userId, experienceId);
+    }
+  }
+
+  /**
+   * Store or replace an affinity entry for (userId, experienceId) in Redis.
+   * Gets the current array, upserts the entry, caps at MAX_ENTRIES, then
+   * writes back with SETEX using AFFINITY_CACHE_TTL_MS.
+   *
+   * @param {string|ObjectId} userId
+   * @param {string|ObjectId} experienceId
+   * @param {Object} entry
+   * @returns {Promise<void>}
+   */
+  async setAffinityEntry(userId, experienceId, entry) {
+    const client = await this._getClient();
+    if (!client) return this._fallback.setAffinityEntry(userId, experienceId, entry);
+    try {
+      const key = this._key(userId);
+      const raw = await client.get(key);
+      let entries = raw ? JSON.parse(raw) : [];
+
+      // Remove any existing entry for this experienceId
+      entries = entries.filter(
+        (e) => e.experience_id.toString() !== experienceId.toString()
+      );
+
+      // Push the new entry
+      entries.push(entry);
+
+      // Cap at MAX_ENTRIES (keep the last/most recent MAX_ENTRIES)
+      if (entries.length > MAX_ENTRIES) {
+        entries = entries.slice(-MAX_ENTRIES);
+      }
+
+      const ttlSeconds = Math.ceil(AFFINITY_CACHE_TTL_MS / 1000);
+      await client.setex(key, ttlSeconds, JSON.stringify(entries));
+    } catch (err) {
+      logger.warn('[affinity-cache] Redis setAffinityEntry failed, falling back to MongoDB', {
+        userId: userId.toString(),
+        experienceId: experienceId.toString(),
+        error: err.message
+      });
+      return this._fallback.setAffinityEntry(userId, experienceId, entry);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton factory
+// ---------------------------------------------------------------------------
+
+let _instance = null;
+
+/**
+ * Create (or return cached) affinity cache instance.
+ * Uses Redis when REDIS_URL is set; falls back to MongoDB.
+ *
+ * @returns {MongoAffinityCache|RedisAffinityCache}
+ */
+function createAffinityCache() {
+  if (_instance) return _instance;
+  if (process.env.REDIS_URL) {
+    logger.info('[affinity-cache] Using Redis affinity cache');
+    _instance = new RedisAffinityCache(process.env.REDIS_URL);
+  } else {
+    logger.info('[affinity-cache] Using MongoDB affinity cache (REDIS_URL not set)');
+    _instance = new MongoAffinityCache();
+  }
+  return _instance;
+}
+
+/** Reset singleton — for tests only. */
+function resetAffinityCache() {
+  _instance = null;
+}
+
+// ---------------------------------------------------------------------------
+// Public convenience wrappers
+// ---------------------------------------------------------------------------
+
+/**
+ * Get a single affinity entry for (userId, experienceId).
+ *
+ * @param {string|ObjectId} userId
+ * @param {string|ObjectId} experienceId
+ * @returns {Promise<Object|null>}
+ */
+async function getAffinityEntry(userId, experienceId) {
+  return createAffinityCache().getAffinityEntry(userId, experienceId);
+}
+
+/**
+ * Store or replace an affinity entry for (userId, experienceId).
+ *
+ * @param {string|ObjectId} userId
+ * @param {string|ObjectId} experienceId
+ * @param {Object} entry
+ * @returns {Promise<void>}
+ */
+async function setAffinityEntry(userId, experienceId, entry) {
+  return createAffinityCache().setAffinityEntry(userId, experienceId, entry);
+}
+
+/**
+ * Build a Map<experienceIdString, entry> for all cached affinity entries of a user.
+ *
+ * @param {string|ObjectId} userId
+ * @returns {Promise<Map<string, Object>>}
+ */
+async function getAffinityMap(userId) {
+  return createAffinityCache().getAffinityMap(userId);
+}
+
+module.exports = {
+  getAffinityEntry,
+  setAffinityEntry,
+  getAffinityMap,
+  resetAffinityCache,
+  createAffinityCache,
+  MongoAffinityCache,
+  RedisAffinityCache,
+  MAX_ENTRIES
+};

--- a/utilities/affinity-cache.js
+++ b/utilities/affinity-cache.js
@@ -40,6 +40,7 @@ class MongoAffinityCache {
 
   /**
    * Build a Map<experienceIdString, entry> for a given user.
+   * Entries older than AFFINITY_CACHE_TTL_MS are excluded (TTL enforcement).
    *
    * @param {string|ObjectId} userId
    * @returns {Promise<Map<string, Object>>}
@@ -50,8 +51,12 @@ class MongoAffinityCache {
       const user = await User.findById(userId).select('affinity_cache').lean();
       if (!user || !Array.isArray(user.affinity_cache)) return new Map();
 
+      const cutoff = Date.now() - AFFINITY_CACHE_TTL_MS;
       const map = new Map();
       for (const entry of user.affinity_cache) {
+        // Skip entries that have passed the TTL (stale affinity scores)
+        const computedAt = entry.computed_at ? new Date(entry.computed_at).getTime() : 0;
+        if (computedAt < cutoff) continue;
         map.set(entry.experience_id.toString(), entry);
       }
       return map;
@@ -66,6 +71,7 @@ class MongoAffinityCache {
 
   /**
    * Retrieve a single affinity entry for (userId, experienceId).
+   * Returns null if the entry is absent or older than AFFINITY_CACHE_TTL_MS.
    *
    * @param {string|ObjectId} userId
    * @param {string|ObjectId} experienceId
@@ -87,8 +93,9 @@ class MongoAffinityCache {
 
   /**
    * Store or replace an affinity entry for (userId, experienceId).
-   * Removes any existing entry with the same experienceId before pushing,
-   * then caps the array at MAX_ENTRIES (keeping the most recent).
+   * Uses a single aggregation pipeline update to atomically filter out any
+   * existing entry for this experienceId, append the new entry, and cap at
+   * MAX_ENTRIES — eliminating the two-step $pull + $push race condition.
    *
    * @param {string|ObjectId} userId
    * @param {string|ObjectId} experienceId
@@ -98,20 +105,32 @@ class MongoAffinityCache {
   async setAffinityEntry(userId, experienceId, entry) {
     try {
       const User = this._getUser();
-      // Step 1: remove existing entry for this experienceId (MongoDB does not
-      // support upsert on subdocument array fields by a nested key).
-      await User.findByIdAndUpdate(userId, {
-        $pull: { affinity_cache: { experience_id: experienceId } }
-      });
-      // Step 2: push new entry with $slice to enforce the cap.
-      await User.findByIdAndUpdate(userId, {
-        $push: {
-          affinity_cache: {
-            $each: [entry],
-            $slice: -MAX_ENTRIES
+      // Atomic: filter existing entry for this experienceId + append new one +
+      // cap at MAX_ENTRIES in a single aggregation pipeline update (MongoDB 4.2+).
+      await User.findByIdAndUpdate(userId, [
+        {
+          $set: {
+            affinity_cache: {
+              $slice: [
+                {
+                  $concatArrays: [
+                    {
+                      $filter: {
+                        input: { $ifNull: ['$affinity_cache', []] },
+                        cond: {
+                          $ne: ['$$this.experience_id', { $toObjectId: experienceId.toString() }]
+                        }
+                      }
+                    },
+                    [entry]
+                  ]
+                },
+                -MAX_ENTRIES
+              ]
+            }
           }
         }
-      });
+      ]);
     } catch (err) {
       logger.warn('[affinity-cache] MongoDB setAffinityEntry failed', {
         userId: userId.toString(),
@@ -130,7 +149,8 @@ class RedisAffinityCache {
   constructor(redisUrl) {
     this._redisUrl = redisUrl;
     this._client = null;
-    this._connecting = false;
+    /** @type {Promise<import('ioredis').Redis|null>|null} */
+    this._connectionPromise = null;
     this._fallback = new MongoAffinityCache();
   }
 
@@ -144,37 +164,48 @@ class RedisAffinityCache {
     return `bien:affinity:${userId.toString()}`;
   }
 
+  /**
+   * Establish the Redis connection. Returns the connected client or null on failure.
+   * Stores the pending Promise so concurrent callers await the same connection
+   * instead of falling through to MongoDB before the first connect resolves.
+   *
+   * @returns {Promise<import('ioredis').Redis|null>}
+   */
   async _getClient() {
     if (this._client) return this._client;
-    if (this._connecting) return null;
-    this._connecting = true;
-    try {
-      const Redis = require('ioredis');
-      const client = new Redis(this._redisUrl, {
-        maxRetriesPerRequest: 1,
-        lazyConnect: true,
-        connectTimeout: 3000,
-        retryStrategy: (times) => (times > 3 ? null : Math.min(times * 200, 2000))
-      });
-      await client.connect();
-      logger.info('[affinity-cache] Redis cache connected');
-      client.on('error', (err) => {
-        logger.warn('[affinity-cache] Redis error, will fallback to MongoDB', {
+    if (this._connectionPromise) return this._connectionPromise;
+
+    this._connectionPromise = (async () => {
+      try {
+        const Redis = require('ioredis');
+        const client = new Redis(this._redisUrl, {
+          maxRetriesPerRequest: 1,
+          lazyConnect: true,
+          connectTimeout: 3000,
+          retryStrategy: (times) => (times > 3 ? null : Math.min(times * 200, 2000))
+        });
+        await client.connect();
+        logger.info('[affinity-cache] Redis cache connected');
+        client.on('error', (err) => {
+          logger.warn('[affinity-cache] Redis error, will fallback to MongoDB', {
+            error: err.message
+          });
+          this._client = null;
+          this._connectionPromise = null;
+        });
+        this._client = client;
+        return this._client;
+      } catch (err) {
+        logger.warn('[affinity-cache] Redis connection failed, using MongoDB fallback', {
           error: err.message
         });
         this._client = null;
-        this._connecting = false;
-      });
-      this._client = client;
-      return this._client;
-    } catch (err) {
-      logger.warn('[affinity-cache] Redis connection failed, using MongoDB fallback', {
-        error: err.message
-      });
-      this._client = null;
-      this._connecting = false;
-      return null;
-    }
+        this._connectionPromise = null;
+        return null;
+      }
+    })();
+
+    return this._connectionPromise;
   }
 
   /**
@@ -190,8 +221,11 @@ class RedisAffinityCache {
       const raw = await client.get(this._key(userId));
       if (!raw) return new Map();
       const entries = JSON.parse(raw);
+      const cutoff = Date.now() - AFFINITY_CACHE_TTL_MS;
       const map = new Map();
       for (const entry of entries) {
+        const computedAt = entry.computed_at ? new Date(entry.computed_at).getTime() : 0;
+        if (computedAt < cutoff) continue;
         map.set(entry.experience_id.toString(), entry);
       }
       return map;
@@ -258,7 +292,9 @@ class RedisAffinityCache {
         entries = entries.slice(-MAX_ENTRIES);
       }
 
-      const ttlSeconds = Math.ceil(AFFINITY_CACHE_TTL_MS / 1000);
+      const ttlSeconds = Number.isFinite(AFFINITY_CACHE_TTL_MS) && AFFINITY_CACHE_TTL_MS > 0
+        ? Math.ceil(AFFINITY_CACHE_TTL_MS / 1000)
+        : 6 * 60 * 60; // 6-hour safe default
       await client.setex(key, ttlSeconds, JSON.stringify(entries));
     } catch (err) {
       logger.warn('[affinity-cache] Redis setAffinityEntry failed, falling back to MongoDB', {

--- a/utilities/affinity-cache.js
+++ b/utilities/affinity-cache.js
@@ -62,7 +62,7 @@ class MongoAffinityCache {
       return map;
     } catch (err) {
       logger.warn('[affinity-cache] MongoDB getAffinityMap failed', {
-        userId: userId.toString(),
+        userId: String(userId),
         error: err.message
       });
       return new Map();
@@ -83,8 +83,8 @@ class MongoAffinityCache {
       return map.get(experienceId.toString()) || null;
     } catch (err) {
       logger.warn('[affinity-cache] MongoDB getAffinityEntry failed', {
-        userId: userId.toString(),
-        experienceId: experienceId.toString(),
+        userId: String(userId),
+        experienceId: String(experienceId),
         error: err.message
       });
       return null;
@@ -105,6 +105,10 @@ class MongoAffinityCache {
   async setAffinityEntry(userId, experienceId, entry) {
     try {
       const User = this._getUser();
+      const mongoose = require('mongoose');
+      // Convert to ObjectId once so the aggregation $ne comparison works reliably
+      // without relying on the server-side $toObjectId cast.
+      const expObjId = new mongoose.Types.ObjectId(experienceId.toString());
       // Atomic: filter existing entry for this experienceId + append new one +
       // cap at MAX_ENTRIES in a single aggregation pipeline update (MongoDB 4.2+).
       await User.findByIdAndUpdate(userId, [
@@ -118,7 +122,7 @@ class MongoAffinityCache {
                       $filter: {
                         input: { $ifNull: ['$affinity_cache', []] },
                         cond: {
-                          $ne: ['$$this.experience_id', { $toObjectId: experienceId.toString() }]
+                          $ne: ['$$this.experience_id', expObjId]
                         }
                       }
                     },
@@ -133,8 +137,8 @@ class MongoAffinityCache {
       ]);
     } catch (err) {
       logger.warn('[affinity-cache] MongoDB setAffinityEntry failed', {
-        userId: userId.toString(),
-        experienceId: experienceId.toString(),
+        userId: String(userId),
+        experienceId: String(experienceId),
         error: err.message
       });
     }
@@ -231,7 +235,7 @@ class RedisAffinityCache {
       return map;
     } catch (err) {
       logger.warn('[affinity-cache] Redis getAffinityMap failed, falling back to MongoDB', {
-        userId: userId.toString(),
+        userId: String(userId),
         error: err.message
       });
       return this._fallback.getAffinityMap(userId);
@@ -253,8 +257,8 @@ class RedisAffinityCache {
       return map.get(experienceId.toString()) || null;
     } catch (err) {
       logger.warn('[affinity-cache] Redis getAffinityEntry failed, falling back to MongoDB', {
-        userId: userId.toString(),
-        experienceId: experienceId.toString(),
+        userId: String(userId),
+        experienceId: String(experienceId),
         error: err.message
       });
       return this._fallback.getAffinityEntry(userId, experienceId);
@@ -298,8 +302,8 @@ class RedisAffinityCache {
       await client.setex(key, ttlSeconds, JSON.stringify(entries));
     } catch (err) {
       logger.warn('[affinity-cache] Redis setAffinityEntry failed, falling back to MongoDB', {
-        userId: userId.toString(),
-        experienceId: experienceId.toString(),
+        userId: String(userId),
+        experienceId: String(experienceId),
         error: err.message
       });
       return this._fallback.setAffinityEntry(userId, experienceId, entry);

--- a/utilities/bienbot-context-builders.js
+++ b/utilities/bienbot-context-builders.js
@@ -14,6 +14,7 @@ const { validateObjectId } = require('./controller-helpers');
 const { findSimilarItems } = require('./fuzzy-match');
 const { aggregateGroupSignals, applySignalDecay, signalsToNaturalLanguage, computePopularityScore, computeAffinityScore } = require('./hidden-signals');
 const signalsConfig = require('./signals-config');
+const affinityCache = require('./affinity-cache');
 
 // Lazy-loaded models (resolved on first use)
 let Destination, Experience, Plan, User, Activity;
@@ -1786,6 +1787,33 @@ async function buildPlanNextStepsContext(planId, userId, options = {}) {
 // ---------------------------------------------------------------------------
 
 /**
+ * Append an [AFFINITY] line to contextLines when the user has meaningful affinity data
+ * for the given experience. Non-fatal — enrichment is best-effort only.
+ *
+ * @param {string[]} contextLines - Mutable lines array to push into.
+ * @param {string|null} userId
+ * @param {string|null} experienceId
+ */
+async function appendAffinityBlock(contextLines, userId, experienceId) {
+  if (!userId || !experienceId) return;
+  try {
+    const entry = await affinityCache.getAffinityEntry(userId, experienceId);
+    if (entry && Math.abs(entry.score - 0.5) > 0.05 && entry.top_dims.length > 0) {
+      const label = entry.score > 0.6 ? 'strong alignment'
+                  : entry.score < 0.4 ? 'low alignment'
+                  : 'moderate alignment';
+      const dimNames = entry.top_dims.map(d => d.dim).join(', ');
+      contextLines.push(
+        `[AFFINITY] User affinity for this experience: ${entry.score.toFixed(2)} (${label} — ${dimNames})`
+      );
+    }
+  } catch (err) {
+    // Non-fatal — affinity enrichment is best-effort
+    logger.warn('[bienbot-context] appendAffinityBlock failed', { error: err.message });
+  }
+}
+
+/**
  * Dispatch to the appropriate builder based on invokeContext.entity.
  *
  * @param {object|null} invokeContext - { entity, entity_id, entity_label }
@@ -1809,10 +1837,32 @@ async function buildContextForInvokeContext(invokeContext, userId, options = {})
   switch (invokeContext.entity) {
     case 'destination':
       return buildDestinationContext(id, userId, options);
-    case 'experience':
-      return buildExperienceContext(id, userId, options);
-    case 'plan':
-      return buildUserPlanContext(id, userId, options);
+    case 'experience': {
+      const contextStr = await buildExperienceContext(id, userId, options);
+      if (!contextStr) return null;
+      const contextLines = [contextStr];
+      await appendAffinityBlock(contextLines, userId, invokeContext.entity_id?.toString());
+      return contextLines.join('\n');
+    }
+    case 'plan': {
+      const contextStr = await buildUserPlanContext(id, userId, options);
+      if (!contextStr) return null;
+      // Resolve the experience_id for affinity enrichment from the plan context.
+      // buildUserPlanContext populates plan.experience._id — re-fetch just the field.
+      let planExperienceId = null;
+      try {
+        loadModels();
+        const planDoc = await Plan.findById(id).select('experience').lean();
+        planExperienceId = planDoc?.experience?.toString() || null;
+      } catch (planExpErr) {
+        logger.warn('[bienbot-context] Could not resolve experience_id for plan affinity block', { planId: id, error: planExpErr.message });
+      }
+      const contextLines = [contextStr];
+      if (planExperienceId) {
+        await appendAffinityBlock(contextLines, userId, planExperienceId);
+      }
+      return contextLines.join('\n');
+    }
     case 'plan_item': {
       // Prefer caller-supplied planId; otherwise auto-resolve from DB.
       if (options.planId) {
@@ -2166,6 +2216,14 @@ async function buildDiscoveryContext(filters = {}, userId, options = {}) {
 
     const formula = signalsConfig.formula;
 
+    // Load affinity map once for all candidates (cache-first; empty Map on failure)
+    let affinityMap = new Map();
+    try {
+      affinityMap = await affinityCache.getAffinityMap(userId);
+    } catch (affinityErr) {
+      logger.warn('[bienbot-context] Failed to load affinity map for discovery ranking', { userId, error: affinityErr.message });
+    }
+
     // Score and rank
     const scored = candidates.map(c => {
       const recencyScore = computeRecencyScore(c.latest_planned_date);
@@ -2190,10 +2248,12 @@ async function buildDiscoveryContext(filters = {}, userId, options = {}) {
         maxPopularity
       );
 
-      // Affinity: similarity between the user's decayed behavioral vector and the
-      // experience's behavioral hidden_signals.  Returns neutralAffinityScore when
-      // either side lacks sufficient confidence (config-driven threshold).
-      const affinityScore = computeAffinityScore(signals, entityBehavior);
+      // Affinity: use pre-loaded cache entry when available; fall back to live
+      // computation for cold-cache candidates (avoids per-candidate DB round-trips).
+      const cachedAffinity = affinityMap.get(c.experience_id.toString());
+      const affinityScore = cachedAffinity
+        ? cachedAffinity.score
+        : computeAffinityScore(signals, entityBehavior);
 
       // Blended formula: formula coefficients from signalsConfig (SIGNALS_CONFIG env var).
       // recencyBoost is always computed fresh — not stored — so it stays accurate between

--- a/utilities/bienbot-context-builders.js
+++ b/utilities/bienbot-context-builders.js
@@ -2227,12 +2227,14 @@ async function buildDiscoveryContext(filters = {}, userId, options = {}) {
 
     const formula = signalsConfig.formula;
 
-    // Load affinity map once for all candidates (cache-first; empty Map on failure)
+    // Load affinity map once for all candidates (cache-first; empty Map on failure or missing userId)
     let affinityMap = new Map();
-    try {
-      affinityMap = await affinityCache.getAffinityMap(userId);
-    } catch (affinityErr) {
-      logger.warn('[bienbot-context] Failed to load affinity map for discovery ranking', { userId, error: affinityErr.message });
+    if (userId) {
+      try {
+        affinityMap = await affinityCache.getAffinityMap(userId);
+      } catch (affinityErr) {
+        logger.warn('[bienbot-context] Failed to load affinity map for discovery ranking', { userId, error: affinityErr.message });
+      }
     }
 
     // Score and rank

--- a/utilities/bienbot-context-builders.js
+++ b/utilities/bienbot-context-builders.js
@@ -12,7 +12,7 @@ const logger = require('./backend-logger');
 const { getEnforcer } = require('./permission-enforcer');
 const { validateObjectId } = require('./controller-helpers');
 const { findSimilarItems } = require('./fuzzy-match');
-const { aggregateGroupSignals, applySignalDecay, signalsToNaturalLanguage, computePopularityScore, computeAffinityScore } = require('./hidden-signals');
+const { aggregateGroupSignals, applySignalDecay, signalsToNaturalLanguage, computePopularityScore, computeAffinityScore, computeAndCacheAffinity } = require('./hidden-signals');
 const signalsConfig = require('./signals-config');
 const affinityCache = require('./affinity-cache');
 
@@ -321,16 +321,24 @@ async function collectPlanNotes(planItems, userId, threshold = 500) {
       // Visibility filter: private notes only visible to author
       if (note.visibility === 'private' && String(note.user) !== String(userId)) continue;
       authorIds.add(String(note.user));
+      const votes = (note.relevancy_votes || []).length;
       allNotes.push({
         itemLabel,
         content: note.content,
         authorId: String(note.user),
-        date: note.createdAt
+        date: note.createdAt,
+        relevancyVotes: votes
       });
     }
   }
 
   if (allNotes.length === 0) return null;
+
+  // Sort: important notes (any votes) first, then by date descending
+  allNotes.sort((a, b) => {
+    if (b.relevancyVotes !== a.relevancyVotes) return b.relevancyVotes - a.relevancyVotes;
+    return new Date(b.date || 0) - new Date(a.date || 0);
+  });
 
   // Batch-resolve author names
   const authorMap = {};
@@ -343,11 +351,14 @@ async function collectPlanNotes(planItems, userId, threshold = 500) {
     logger.debug('[bienbot-context] Author name resolution failed', { error: err.message });
   }
 
-  // Format notes
+  // Format notes — prepend [IMPORTANT (N votes)] for voted notes, [NEUTRAL] otherwise
   const noteLines = allNotes.map(n => {
     const author = authorMap[n.authorId] || 'Unknown';
     const dateStr = n.date ? new Date(n.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : '';
-    return `- [${author}${dateStr ? `, ${dateStr}` : ''}] (${n.itemLabel}): ${n.content}`;
+    const importantTag = n.relevancyVotes > 0
+      ? `[IMPORTANT (${n.relevancyVotes} vote${n.relevancyVotes === 1 ? '' : 's'})] `
+      : '[NEUTRAL] ';
+    return `- ${importantTag}[${author}${dateStr ? `, ${dateStr}` : ''}] (${n.itemLabel}): ${n.content}`;
   });
 
   const totalChars = noteLines.reduce((sum, l) => sum + l.length, 0);
@@ -358,7 +369,7 @@ async function collectPlanNotes(planItems, userId, threshold = 500) {
       const { executeAIRequest } = require('./ai-gateway');
       const result = await executeAIRequest({
         messages: [
-          { role: 'system', content: 'Summarize these travel plan notes concisely, preserving key details and who said what. Output only the summary.' },
+          { role: 'system', content: 'Summarize these travel plan notes concisely, preserving key details and who said what. Each note is tagged [IMPORTANT (N votes)] or [NEUTRAL]. IMPORTANT notes have been explicitly marked as high-priority by plan members and contain details the team considers critical to the plan (e.g. confirmed bookings, restrictions, must-dos). NEUTRAL notes are general remarks or lower-priority information. Prioritize IMPORTANT note content in your summary — their key points must appear. NEUTRAL notes may be condensed or omitted if space is tight. Output only the summary.' },
           { role: 'user', content: noteLines.join('\n') }
         ],
         user: null, // context builder does not hold a user document; usage tracking is skipped
@@ -2250,10 +2261,17 @@ async function buildDiscoveryContext(filters = {}, userId, options = {}) {
 
       // Affinity: use pre-loaded cache entry when available; fall back to live
       // computation for cold-cache candidates (avoids per-candidate DB round-trips).
+      // On a cache miss, fire-and-forget computeAndCacheAffinity so subsequent
+      // requests for the same (user, experience) pair hit the cache.
       const cachedAffinity = affinityMap.get(c.experience_id.toString());
-      const affinityScore = cachedAffinity
-        ? cachedAffinity.score
-        : computeAffinityScore(signals, entityBehavior);
+      let affinityScore;
+      if (cachedAffinity) {
+        affinityScore = cachedAffinity.score;
+      } else {
+        affinityScore = computeAffinityScore(signals, entityBehavior);
+        // Warm the cache asynchronously — never awaited, never throws
+        computeAndCacheAffinity(userId, c.experience_id).catch(() => {});
+      }
 
       // Blended formula: formula coefficients from signalsConfig (SIGNALS_CONFIG env var).
       // recencyBoost is always computed fresh — not stored — so it stays accurate between

--- a/utilities/hidden-signals.js
+++ b/utilities/hidden-signals.js
@@ -632,6 +632,127 @@ async function updateExperienceSignals(experienceId) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Affinity cache: compute + store
+// ---------------------------------------------------------------------------
+
+/**
+ * Load hidden_signals for a user and an experience, compute the affinity score
+ * and top aligned dimensions, then persist the result to the affinity cache.
+ *
+ * Returns early (without writing to the cache) when:
+ *  - Either ID is not a valid ObjectId.
+ *  - The user or experience document is not found in the database.
+ *
+ * Never throws — errors are logged and silently absorbed by the caller.
+ *
+ * @param {string|import('mongoose').Types.ObjectId} userId
+ * @param {string|import('mongoose').Types.ObjectId} experienceId
+ * @returns {Promise<void>}
+ */
+async function computeAndCacheAffinity(userId, experienceId) {
+  const mongoose = require('mongoose');
+  const affinityCache = require('./affinity-cache');
+
+  // Validate IDs before hitting the database
+  if (!mongoose.Types.ObjectId.isValid(userId) || !mongoose.Types.ObjectId.isValid(experienceId)) {
+    backendLogger.warn('[hidden-signals] computeAndCacheAffinity: invalid ObjectId', {
+      userId: userId?.toString(),
+      experienceId: experienceId?.toString()
+    });
+    return;
+  }
+
+  // Load documents (lean, selecting only the field we need)
+  const User       = require('../models/user');
+  const Experience = require('../models/experience');
+
+  const [user, experience] = await Promise.all([
+    User.findById(userId).select('hidden_signals').lean(),
+    Experience.findById(experienceId).select('hidden_signals').lean()
+  ]);
+
+  if (!user) {
+    backendLogger.warn('[hidden-signals] computeAndCacheAffinity: user not found', {
+      userId: userId.toString()
+    });
+    return;
+  }
+
+  if (!experience) {
+    backendLogger.warn('[hidden-signals] computeAndCacheAffinity: experience not found', {
+      experienceId: experienceId.toString()
+    });
+    return;
+  }
+
+  // Apply temporal decay to both vectors
+  const decayedUser   = applySignalDecay(user.hidden_signals   || {});
+  const decayedEntity = applySignalDecay(experience.hidden_signals || {});
+
+  // Compute overall affinity score
+  const score = computeAffinityScore(decayedUser, decayedEntity);
+
+  // Identify top aligned dimensions (delta < 0.3), sorted ascending by delta,
+  // capped at 3.
+  const dimEntries = DIMENSIONS.map((dim) => {
+    const userVal   = typeof decayedUser[dim]   === 'number' ? decayedUser[dim]   : NEUTRAL;
+    const entityVal = typeof decayedEntity[dim] === 'number' ? decayedEntity[dim] : NEUTRAL;
+    const delta     = Math.abs(userVal - entityVal);
+    return { dim, user_val: userVal, entity_val: entityVal, delta };
+  });
+
+  const top_dims = dimEntries
+    .filter((d) => d.delta < 0.3)
+    .sort((a, b) => a.delta - b.delta)
+    .slice(0, 3);
+
+  const entry = {
+    experience_id: experienceId,
+    score,
+    top_dims,
+    computed_at: new Date()
+  };
+
+  await affinityCache.setAffinityEntry(userId, experienceId, entry);
+
+  backendLogger.debug('[hidden-signals] computeAndCacheAffinity: affinity cached', {
+    userId: userId.toString(),
+    experienceId: experienceId.toString(),
+    score,
+    topDimsCount: top_dims.length
+  });
+}
+
+/**
+ * Fire-and-forget: check whether experience content signals are stale; if so,
+ * recompute them, then compute and cache the user ↔ experience affinity score.
+ *
+ * Never throws — errors are logged and silently absorbed.
+ *
+ * @param {string|import('mongoose').Types.ObjectId} experienceId
+ * @param {string|import('mongoose').Types.ObjectId} userId
+ * @param {Date|string|null} computedAt - Timestamp of last signal computation.
+ * @returns {Promise<void>}
+ */
+async function refreshSignalsAndAffinity(experienceId, userId, computedAt) {
+  try {
+    const config = require('./signals-config');
+    const isStale = !computedAt || (Date.now() - new Date(computedAt).getTime() > config.SIGNALS_STALENESS_MS);
+    if (isStale) {
+      await updateExperienceSignals(experienceId); // awaited so affinity reads fresh signals
+    }
+    await computeAndCacheAffinity(userId, experienceId);
+  } catch (err) {
+    backendLogger.error('[hidden-signals] refreshSignalsAndAffinity failed', {
+      experienceId: experienceId?.toString(),
+      userId,
+      error: err.message
+    });
+    // Never throw — fire-and-forget
+  }
+}
+
 module.exports = {
   // Constants (exported for testing)
   ACTIVITY_TYPE_SIGNAL_MAP,
@@ -652,5 +773,7 @@ module.exports = {
   computeAffinityScore,
   // Side-effectful
   processSignalEvent,
-  updateExperienceSignals
+  updateExperienceSignals,
+  computeAndCacheAffinity,
+  refreshSignalsAndAffinity
 };

--- a/utilities/hidden-signals.js
+++ b/utilities/hidden-signals.js
@@ -744,6 +744,7 @@ async function computeAndCacheAffinity(userId, experienceId) {
  * @returns {Promise<void>}
  */
 async function refreshSignalsAndAffinity(experienceId, userId, computedAt) {
+  if (!userId) return; // No-op without a user — avoids log noise from unauthenticated paths
   try {
     const config = require('./signals-config');
     const isStale = !computedAt || (Date.now() - new Date(computedAt).getTime() > config.SIGNALS_STALENESS_MS);

--- a/utilities/hidden-signals.js
+++ b/utilities/hidden-signals.js
@@ -115,7 +115,8 @@ function updateHiddenSignals(currentSignals, event) {
   const influence = activityType ? ACTIVITY_TYPE_SIGNAL_MAP[activityType] : null;
   const eventWeight = EVENT_WEIGHT_MAP[event.type] ?? 0;
   const eventValue = typeof event.value === 'number' ? event.value : 0;
-  const combinedWeight = eventWeight * (eventValue || 1);
+  // Use explicit non-zero check so value:0 (valid falsy number) is not replaced with 1.
+  const combinedWeight = eventWeight * (eventValue !== 0 ? eventValue : 1);
 
   if (influence) {
     for (const [dim, strength] of Object.entries(influence)) {
@@ -142,37 +143,41 @@ function aggregateGroupSignals(userDocuments) {
     return { confidence: 0 };
   }
 
-  const sums = {};
-  const sqSums = {};
-  let totalConfidence = 0;
-  const count = userDocuments.length;
+  const weightedSums = {};
+  const sqWeightedSums = {};
+  let totalWeight = 0;
 
   for (const dim of DIMENSIONS) {
-    sums[dim] = 0;
-    sqSums[dim] = 0;
+    weightedSums[dim] = 0;
+    sqWeightedSums[dim] = 0;
   }
 
   for (const doc of userDocuments) {
     const sig = doc.hidden_signals || {};
+    // Use each user's confidence as their weight — high-confidence profiles
+    // (many signal events) influence the group average more than sparse ones.
+    const w = typeof sig.confidence === 'number' && sig.confidence > 0 ? sig.confidence : 0.01;
+    totalWeight += w;
     for (const dim of DIMENSIONS) {
       const val = typeof sig[dim] === 'number' ? sig[dim] : NEUTRAL;
-      sums[dim] += val;
-      sqSums[dim] += val * val;
+      weightedSums[dim] += val * w;
+      sqWeightedSums[dim] += val * val * w;
     }
-    totalConfidence += typeof sig.confidence === 'number' ? sig.confidence : 0;
   }
 
   const result = {};
   let varianceSum = 0;
 
   for (const dim of DIMENSIONS) {
-    result[dim] = sums[dim] / count;
-    const variance = (sqSums[dim] / count) - (result[dim] * result[dim]);
-    varianceSum += Math.max(0, variance);
+    result[dim] = weightedSums[dim] / totalWeight;
+    // Bessel-corrected weighted variance approximation
+    const rawVariance = (sqWeightedSums[dim] / totalWeight) - (result[dim] * result[dim]);
+    varianceSum += Math.max(0, rawVariance);
   }
 
   const avgVariance = varianceSum / DIMENSIONS.length;
-  const avgConfidence = totalConfidence / count;
+  // Group confidence: average of individual confidences, penalised by intra-group variance
+  const avgConfidence = totalWeight / userDocuments.length;
   result.confidence = clamp01(avgConfidence * (1 - avgVariance));
   result.last_updated = new Date();
 
@@ -255,6 +260,9 @@ function applySignalDecay(signals) {
 /**
  * Inject a high-novelty "surprise" recommendation when the user's novelty
  * score is low.
+ *
+ * @internal Not exported — candidate for wiring into discovery ranking once
+ *   the scored output carries per-candidate hidden_signals.
  *
  * @param {Array<Object>} recommendations - Array of experience/destination objects.
  * @param {Object} userSignals - User's signal vector.
@@ -766,7 +774,6 @@ module.exports = {
   aggregateGroupSignals,
   signalsToNaturalLanguage,
   applySignalDecay,
-  injectSurprise,
   computeExperienceSignalTags,
   computeTrustScore,
   computePopularityScore,

--- a/utilities/signals-config.js
+++ b/utilities/signals-config.js
@@ -87,6 +87,12 @@ const DEFAULTS = {
     /** Share going to the user ↔ experience hidden_signals affinity score. */
     affinity: 0.10,
   },
+  /**
+   * Top-level scalar config keys (not weight groups — never normalised).
+   * Stored directly on the config object, not nested inside a weight group.
+   */
+  SIGNALS_STALENESS_MS:   15 * 60 * 1000,  // 15 minutes
+  AFFINITY_CACHE_TTL_MS:   6 * 60 * 60 * 1000, // 6 hours
 };
 
 // Keys whose numeric values are weights and should be normalised to sum to 1.
@@ -239,6 +245,15 @@ function loadSignalsConfig() {
       groupName
     );
     merged[groupName] = normaliseWeights(merged[groupName]);
+  }
+
+  // Pass through top-level scalar keys (not weight groups)
+  const SCALAR_KEYS = ['SIGNALS_STALENESS_MS', 'AFFINITY_CACHE_TTL_MS'];
+  for (const key of SCALAR_KEYS) {
+    const overrideVal = override[key];
+    merged[key] = (typeof overrideVal === 'number' && isFinite(overrideVal) && overrideVal > 0)
+      ? overrideVal
+      : DEFAULTS[key];
   }
 
   const config = Object.freeze(merged);

--- a/utilities/signals-config.js
+++ b/utilities/signals-config.js
@@ -251,9 +251,19 @@ function loadSignalsConfig() {
   const SCALAR_KEYS = ['SIGNALS_STALENESS_MS', 'AFFINITY_CACHE_TTL_MS'];
   for (const key of SCALAR_KEYS) {
     const overrideVal = override[key];
-    merged[key] = (typeof overrideVal === 'number' && isFinite(overrideVal) && overrideVal > 0)
-      ? overrideVal
-      : DEFAULTS[key];
+    if (overrideVal !== undefined) {
+      if (typeof overrideVal === 'number' && isFinite(overrideVal) && overrideVal > 0) {
+        merged[key] = overrideVal;
+      } else {
+        logger.warn(`[signals-config] ${key} must be a finite positive number; using default`, {
+          received: overrideVal,
+          default: DEFAULTS[key],
+        });
+        merged[key] = DEFAULTS[key];
+      }
+    } else {
+      merged[key] = DEFAULTS[key];
+    }
   }
 
   const config = Object.freeze(merged);


### PR DESCRIPTION
Sourcery fixes landed:

- affinity-cache.js — $toObjectId → pre-constructed mongoose.Types.ObjectId; String() instead of .toString() in catch blocks
- bienbot-context-builders.js — getAffinityMap guarded by if (userId)
- hidden-signals.js — early return in refreshSignalsAndAffinity when userId is falsy
- ai.md — typo fix: "undecked" → "undecayed"

New tests added:
- affinity-cache.test.js — test 6: TTL filtering (stale entries excluded from getAffinityMap/getAffinityEntry)
- bienbot-context-affinity.test.js — error handling test (cache error swallowed, no [AFFINITY] block), plan entity path test (resolves experience from plan doc, appends [AFFINITY])
- hidden-signals-affinity.test.js — test 7 strengthened with explicit setAffinityEntry call count assertion

## Summary by Sourcery

Introduce a user–experience affinity caching system backed by Redis or MongoDB, integrate affinity signals into BienBot context and discovery ranking, and improve mobile step indicators in destination and experience wizards.

New Features:
- Add an affinity cache abstraction with Redis primary and MongoDB fallback providers for storing per-user experience affinity entries.
- Surface affinity information into BienBot invoke and discovery contexts, including narrative-friendly [AFFINITY] blocks and system-prompt guidance.
- Document the hidden signals, content signals, affinity computation, caching, and configuration behavior in ai.md, including TTL and staleness handling.
- Introduce responsive step indicators that show a compact dropdown on mobile/tablet and a horizontal stepper on desktop in destination and experience wizards.

Bug Fixes:
- Ensure hidden-signal aggregation ignores unused squared-weight accumulation to simplify group computations.

Enhancements:
- Add staleness-aware refresh logic that recomputes content signals and affinity on experience/plan loads without impacting response latency.
- Extend the user model with a bounded affinity cache subdocument array to support MongoDB-backed caching.
- Refine signals configuration handling to support non-normalised scalar keys such as SIGNALS_STALENESS_MS and AFFINITY_CACHE_TTL_MS.

Documentation:
- Expand ai.md with detailed sections covering hidden signals, content signals, affinity scoring, caching, staleness refresh, BienBot integration, and signals configuration.

Tests:
- Add unit tests for affinity caching providers, hidden-signals affinity computation and refresh behavior, BienBot affinity context injection, and scalar signals-config handling.